### PR TITLE
attention: add USE_TD constexpr for tensor descriptor Q/K/V load/store

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
     VLLM_MAIN_CUDA_VERSION: str = "12.9"
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
     VLLM_BATCH_INVARIANT: bool = False
+    VLLM_TRITON_USE_TD: bool | None = None
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
     VLLM_USE_PRECOMPILED: bool = False
@@ -506,6 +507,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable batch-invariant mode: deterministic results regardless of
     # batch composition. Requires NVIDIA GPU with compute capability >= 9.0.
     "VLLM_BATCH_INVARIANT": lambda: bool(int(os.getenv("VLLM_BATCH_INVARIANT", "0"))),
+    # Use tensor descriptors in Triton unified attention.
+    # None = auto-detect (XPU → True, else False). Set 1/0 to override.
+    "VLLM_TRITON_USE_TD":
+    lambda: {"1": True, "0": False}.get(os.getenv("VLLM_TRITON_USE_TD", "").strip()),
     # Maximum number of compilation jobs to run in parallel.
     # By default this is the number of CPUs
     "MAX_JOBS": lambda: os.getenv("MAX_JOBS", None),

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -204,7 +204,7 @@ class TokenizeParams:
             and max_output_tokens > max_total_tokens
         ):
             raise VLLMValidationError(
-                f"{self.max_output_tokens_param}={max_output_tokens}"
+                f"{self.max_output_tokens_param}={max_output_tokens} "
                 f"cannot be greater than "
                 f"{self.max_total_tokens_param}={max_total_tokens=}. "
                 f"Please request fewer output tokens.",

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -497,6 +497,17 @@ class TritonAttentionImpl(AttentionImpl):
         self._kv_quant_mode = get_kv_quant_mode(kv_cache_dtype)
         self._is_per_token_head_quant = self._kv_quant_mode.is_per_token_head
 
+        # Enable tensor descriptors for Q/K/V load/store on platforms that
+        # benefit from HW 2D block reads (Intel Xe2/Xe3).  The dead branch
+        # is eliminated at Triton compile time, so NVIDIA/AMD see zero cost.
+        # Override with VLLM_TRITON_USE_TD=1/0 for benchmarking.
+        import vllm.envs as envs
+        td_override = envs.VLLM_TRITON_USE_TD
+        if td_override is not None:
+            self.use_td = td_override
+        else:
+            self.use_td = current_platform.is_xpu()
+
     def forward(
         self,
         layer: torch.nn.Module,
@@ -631,6 +642,7 @@ class TritonAttentionImpl(AttentionImpl):
             kv_quant_mode=self._kv_quant_mode,
             k_scale_cache=k_scale_cache,
             v_scale_cache=v_scale_cache,
+            use_td=self.use_td,
         )
 
         return output

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -91,6 +91,90 @@ def _prepare_kv_tile(
 
 
 @triton.jit
+def _load_q_td(
+    query_ptr,
+    q_block_local_len,
+    query_stride_0: tl.int64,
+    query_stride_1: tl.int64,
+    cur_batch_in_all_start_index,
+    q_block_local_idx,
+    kv_head_idx,
+    num_queries_per_kv: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+):
+    """Load Q via tensor descriptor. Returns (BLOCK_M, HEAD_SIZE_PADDED)."""
+    q_base = (
+        query_ptr
+        + (cur_batch_in_all_start_index
+           + q_block_local_idx * BLOCK_Q) * query_stride_0
+        + (kv_head_idx * num_queries_per_kv) * query_stride_1
+    )
+    if HEAD_SIZE == HEAD_SIZE_PADDED:
+        q_desc = tl.make_tensor_descriptor(
+            base=q_base,
+            shape=(q_block_local_len,
+                   num_queries_per_kv * HEAD_SIZE),
+            strides=(query_stride_0, 1),
+            block_shape=(BLOCK_Q,
+                         num_queries_per_kv * HEAD_SIZE_PADDED),
+        )
+        return q_desc.load([0, 0]).reshape(BLOCK_M, HEAD_SIZE_PADDED)
+    else:
+        q_desc = tl.make_tensor_descriptor(
+            base=q_base,
+            shape=(q_block_local_len,
+                   num_queries_per_kv, HEAD_SIZE),
+            strides=(query_stride_0, query_stride_1, 1),
+            block_shape=(BLOCK_Q,
+                         num_queries_per_kv, HEAD_SIZE_PADDED),
+        )
+        return q_desc.load([0, 0, 0]).reshape(BLOCK_M, HEAD_SIZE_PADDED)
+
+
+@triton.jit
+def _load_kv_tile_td(
+    cache_ptr,
+    physical_block_idx_scalar,
+    kv_head_idx,
+    offset_in_block,
+    stride_cache_0: tl.int64,
+    stride_cache_1: tl.int64,
+    stride_cache_2: tl.int64,
+    stride_cache_3: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    TILE_SIZE: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+    IS_K: tl.constexpr,
+):
+    """Load a KV cache tile via tensor descriptor.
+
+    Returns (TILE_SIZE, HEAD_SIZE_PADDED) for V or
+    (HEAD_SIZE_PADDED, TILE_SIZE) for K (transposed).
+    Tensor descriptors zero-pad reads beyond the shape boundary,
+    so HEAD_SIZE_PADDED > HEAD_SIZE is handled correctly.
+    """
+    base = (
+        cache_ptr
+        + physical_block_idx_scalar * stride_cache_0
+        + kv_head_idx * stride_cache_2
+    )
+    desc = tl.make_tensor_descriptor(
+        base=base,
+        shape=(BLOCK_SIZE, HEAD_SIZE),
+        strides=(stride_cache_1, stride_cache_3),
+        block_shape=(TILE_SIZE, HEAD_SIZE_PADDED),
+    )
+    tile = desc.load([offset_in_block, 0])
+    if IS_K:
+        return tile.T
+    return tile
+
+
+@triton.jit
 def find_seq_idx(
     query_start_len_ptr,
     target_idx,
@@ -163,6 +247,7 @@ def kernel_unified_attention_2d(
     num_seqs: tl.int32,
     BLOCK_M: tl.constexpr,  # int
     USE_FP8: tl.constexpr,  # bool
+    USE_TD: tl.constexpr = False,  # Use tensor descriptors for load/store
     # KV cache quantization: 0=none, 1=fp8, 2=per-token-head
     KV_QUANT_MODE: tl.constexpr = 0,
     FP8_MIN: tl.constexpr = float8_info.min,
@@ -197,6 +282,18 @@ def kernel_unified_attention_2d(
     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
         return
 
+    if USE_TD:
+        tl.static_assert(
+            BLOCK_SIZE % TILE_SIZE == 0,
+            "USE_TD requires BLOCK_SIZE to be a multiple of TILE_SIZE",
+        )
+
+    # Number of valid query rows in this block (used by TD path for
+    # descriptor shapes, but always computed to keep variable in scope).
+    q_block_local_len = tl.minimum(
+        BLOCK_Q, cur_batch_query_len - q_block_local_idx * BLOCK_Q
+    )
+
     offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
     offs_t = tl.arange(0, TILE_SIZE)
@@ -215,11 +312,21 @@ def kernel_unified_attention_2d(
     query_mask_1 = tl.where(query_offset_1 < num_query_heads, 1, 0).to(tl.int1)
 
     # Q : (BLOCK_M, HEAD_SIZE_PADDED)
-    Q = tl.load(
-        query_ptr + query_offset,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
-        other=0.0,
-    )
+    if USE_TD:
+        Q = _load_q_td(
+            query_ptr, q_block_local_len,
+            query_stride_0, query_stride_1,
+            cur_batch_in_all_start_index, q_block_local_idx,
+            kv_head_idx, num_queries_per_kv,
+            BLOCK_Q, BLOCK_M, HEAD_SIZE, HEAD_SIZE_PADDED,
+        )
+    else:
+        Q = tl.load(
+            query_ptr + query_offset,
+            mask=dim_mask[None, :] & query_mask_0[:, None]
+                 & query_mask_1[:, None],
+            other=0.0,
+        )
 
     block_table_offset = seq_idx * block_table_stride
 
@@ -308,63 +415,98 @@ def kernel_unified_attention_2d(
             block_tables_ptr + block_table_offset + seq_offset // BLOCK_SIZE
         ).to(tl.int64)
 
-        v_offset = (
-            physical_block_idx[:, None] * stride_v_cache_0
-            + kv_head_idx * stride_v_cache_2
-            + offs_d[None, :] * stride_v_cache_3
-            + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
-        )
+        if USE_TD:
+            # --- Tensor-descriptor path for K/V loads ---
+            # static_assert guarantees tile stays inside one physical block.
+            offset_in_block = (j * TILE_SIZE) % BLOCK_SIZE
+            K_load = _load_kv_tile_td(
+                key_cache_ptr, physical_block_idx[0], kv_head_idx,
+                offset_in_block,
+                stride_k_cache_0, stride_k_cache_1,
+                stride_k_cache_2, stride_k_cache_3,
+                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                IS_K=True,
+            )
+            V_load = _load_kv_tile_td(
+                value_cache_ptr, physical_block_idx[0], kv_head_idx,
+                offset_in_block,
+                stride_v_cache_0, stride_v_cache_1,
+                stride_v_cache_2, stride_v_cache_3,
+                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                IS_K=False,
+            )
 
-        k_offset = (
-            physical_block_idx[None, :] * stride_k_cache_0
-            + kv_head_idx * stride_k_cache_2
-            + offs_d[:, None] * stride_k_cache_3
-            + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
-        )
+            K, k_token_head_scales = _prepare_kv_tile(
+                K_load, Q, k_scale, k_scale_cache_ptr,
+                physical_block_idx, seq_offset, kv_head_idx,
+                stride_ks_blk, stride_ks_slot, stride_ks_head,
+                tile_mask, BLOCK_SIZE, KV_QUANT_MODE,
+            )
+            V, v_token_head_scales = _prepare_kv_tile(
+                V_load, Q, v_scale, v_scale_cache_ptr,
+                physical_block_idx, seq_offset, kv_head_idx,
+                stride_vs_blk, stride_vs_slot, stride_vs_head,
+                tile_mask, BLOCK_SIZE, KV_QUANT_MODE,
+            )
+        else:
+            # --- Original pointer-arithmetic path for K/V loads ---
+            v_offset = (
+                physical_block_idx[:, None] * stride_v_cache_0
+                + kv_head_idx * stride_v_cache_2
+                + offs_d[None, :] * stride_v_cache_3
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            )
 
-        # K : (HEAD_SIZE, TILE_SIZE)
-        K_load = tl.load(
-            key_cache_ptr + k_offset,
-            mask=dim_mask[:, None] & tile_mask[None, :],
-            other=0.0,
-        )
-        K, k_token_head_scales = _prepare_kv_tile(
-            K_load,
-            Q,
-            k_scale,
-            k_scale_cache_ptr,
-            physical_block_idx,
-            seq_offset,
-            kv_head_idx,
-            stride_ks_blk,
-            stride_ks_slot,
-            stride_ks_head,
-            tile_mask,
-            BLOCK_SIZE,
-            KV_QUANT_MODE,
-        )
+            k_offset = (
+                physical_block_idx[None, :] * stride_k_cache_0
+                + kv_head_idx * stride_k_cache_2
+                + offs_d[:, None] * stride_k_cache_3
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+            )
 
-        # V : (TILE_SIZE, HEAD_SIZE)
-        V_load = tl.load(
-            value_cache_ptr + v_offset,
-            mask=dim_mask[None, :] & tile_mask[:, None],
-            other=0.0,
-        )
-        V, v_token_head_scales = _prepare_kv_tile(
-            V_load,
-            Q,
-            v_scale,
-            v_scale_cache_ptr,
-            physical_block_idx,
-            seq_offset,
-            kv_head_idx,
-            stride_vs_blk,
-            stride_vs_slot,
-            stride_vs_head,
-            tile_mask,
-            BLOCK_SIZE,
-            KV_QUANT_MODE,
-        )
+            # K : (HEAD_SIZE, TILE_SIZE)
+            K_load = tl.load(
+                key_cache_ptr + k_offset,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0.0,
+            )
+            K, k_token_head_scales = _prepare_kv_tile(
+                K_load,
+                Q,
+                k_scale,
+                k_scale_cache_ptr,
+                physical_block_idx,
+                seq_offset,
+                kv_head_idx,
+                stride_ks_blk,
+                stride_ks_slot,
+                stride_ks_head,
+                tile_mask,
+                BLOCK_SIZE,
+                KV_QUANT_MODE,
+            )
+
+            # V : (TILE_SIZE, HEAD_SIZE)
+            V_load = tl.load(
+                value_cache_ptr + v_offset,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0.0,
+            )
+            V, v_token_head_scales = _prepare_kv_tile(
+                V_load,
+                Q,
+                v_scale,
+                v_scale_cache_ptr,
+                physical_block_idx,
+                seq_offset,
+                kv_head_idx,
+                stride_vs_blk,
+                stride_vs_slot,
+                stride_vs_head,
+                tile_mask,
+                BLOCK_SIZE,
+                KV_QUANT_MODE,
+            )
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -484,17 +626,37 @@ def kernel_unified_attention_2d(
         acc = acc * tl.load(out_scale)
         acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
 
-    output_offset = (
-        query_offset_0[:, None] * output_stride_0
-        + query_offset_1[:, None] * output_stride_1
-        + offs_d[None, :]
-    )
+    if USE_TD:
+        acc = acc.to(output_ptr.dtype.element_ty)
+        output_base = (
+            output_ptr
+            + (cur_batch_in_all_start_index
+               + q_block_local_idx * BLOCK_Q) * output_stride_0
+            + (kv_head_idx * num_queries_per_kv) * output_stride_1
+        )
+        output_desc = tl.make_tensor_descriptor(
+            base=output_base,
+            shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
+            strides=(output_stride_0, output_stride_1, 1),
+            block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        )
+        output_desc.store(
+            [0, 0, 0],
+            acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        )
+    else:
+        output_offset = (
+            query_offset_0[:, None] * output_stride_0
+            + query_offset_1[:, None] * output_stride_1
+            + offs_d[None, :]
+        )
 
-    tl.store(
-        output_ptr + output_offset,
-        acc,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
-    )
+        tl.store(
+            output_ptr + output_offset,
+            acc,
+            mask=dim_mask[None, :] & query_mask_0[:, None]
+                 & query_mask_1[:, None],
+        )
 
 
 @triton.jit
@@ -547,6 +709,7 @@ def kernel_unified_attention_3d(
     USE_MM_PREFIX: tl.constexpr,  # bool
     MAX_MM_RANGES: tl.constexpr,  # int
     mm_prefix_range_ptr,  # [num_seqs] - prefix length for each sequence
+    USE_TD: tl.constexpr = False,  # Use tensor descriptors for load/store
     # KV cache quantization: 0=none, 1=fp8, 2=per-token-head
     KV_QUANT_MODE: tl.constexpr = 0,
     # Per-token-head scale caches (KV_QUANT_MODE >= 2)
@@ -580,6 +743,12 @@ def kernel_unified_attention_3d(
     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
         return
 
+    if USE_TD:
+        tl.static_assert(
+            BLOCK_SIZE % TILE_SIZE == 0,
+            "USE_TD requires BLOCK_SIZE to be a multiple of TILE_SIZE",
+        )
+
     # sequence len for this particular sequence
     seq_len = tl.load(seq_lens_ptr + seq_idx)
 
@@ -589,6 +758,12 @@ def kernel_unified_attention_3d(
 
     if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
         return
+
+    # Number of valid query rows in this block (used by TD path for
+    # descriptor shapes, but always computed to keep variable in scope).
+    q_block_local_len = tl.minimum(
+        BLOCK_Q, cur_batch_query_len - q_block_local_idx * BLOCK_Q
+    )
 
     offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
@@ -608,11 +783,21 @@ def kernel_unified_attention_3d(
     query_mask_1 = tl.where(query_offset_1 < num_query_heads, 1, 0).to(tl.int1)
 
     # Q : (BLOCK_M, HEAD_SIZE_PADDED)
-    Q = tl.load(
-        query_ptr + query_offset,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
-        other=0.0,
-    )
+    if USE_TD:
+        Q = _load_q_td(
+            query_ptr, q_block_local_len,
+            query_stride_0, query_stride_1,
+            cur_batch_in_all_start_index, q_block_local_idx,
+            kv_head_idx, num_queries_per_kv,
+            BLOCK_Q, BLOCK_M, HEAD_SIZE, HEAD_SIZE_PADDED,
+        )
+    else:
+        Q = tl.load(
+            query_ptr + query_offset,
+            mask=dim_mask[None, :] & query_mask_0[:, None]
+                 & query_mask_1[:, None],
+            other=0.0,
+        )
 
     block_table_offset = seq_idx * block_table_stride
 
@@ -699,63 +884,98 @@ def kernel_unified_attention_3d(
             block_tables_ptr + block_table_offset + seq_offset // BLOCK_SIZE
         ).to(tl.int64)
 
-        v_offset = (
-            physical_block_idx[:, None] * stride_v_cache_0
-            + kv_head_idx * stride_v_cache_2
-            + offs_d[None, :] * stride_v_cache_3
-            + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
-        )
+        if USE_TD:
+            # --- Tensor-descriptor path for K/V loads ---
+            # static_assert guarantees tile stays inside one physical block.
+            offset_in_block = (j * TILE_SIZE) % BLOCK_SIZE
+            K_load = _load_kv_tile_td(
+                key_cache_ptr, physical_block_idx[0], kv_head_idx,
+                offset_in_block,
+                stride_k_cache_0, stride_k_cache_1,
+                stride_k_cache_2, stride_k_cache_3,
+                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                IS_K=True,
+            )
+            V_load = _load_kv_tile_td(
+                value_cache_ptr, physical_block_idx[0], kv_head_idx,
+                offset_in_block,
+                stride_v_cache_0, stride_v_cache_1,
+                stride_v_cache_2, stride_v_cache_3,
+                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                IS_K=False,
+            )
 
-        k_offset = (
-            physical_block_idx[None, :] * stride_k_cache_0
-            + kv_head_idx * stride_k_cache_2
-            + offs_d[:, None] * stride_k_cache_3
-            + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
-        )
+            K, k_token_head_scales = _prepare_kv_tile(
+                K_load, Q, k_scale, k_scale_cache_ptr,
+                physical_block_idx, seq_offset, kv_head_idx,
+                stride_ks_blk, stride_ks_slot, stride_ks_head,
+                tile_mask, BLOCK_SIZE, KV_QUANT_MODE,
+            )
+            V, v_token_head_scales = _prepare_kv_tile(
+                V_load, Q, v_scale, v_scale_cache_ptr,
+                physical_block_idx, seq_offset, kv_head_idx,
+                stride_vs_blk, stride_vs_slot, stride_vs_head,
+                tile_mask, BLOCK_SIZE, KV_QUANT_MODE,
+            )
+        else:
+            # --- Original pointer-arithmetic path for K/V loads ---
+            v_offset = (
+                physical_block_idx[:, None] * stride_v_cache_0
+                + kv_head_idx * stride_v_cache_2
+                + offs_d[None, :] * stride_v_cache_3
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            )
 
-        # K : (HEAD_SIZE, TILE_SIZE)
-        K_load = tl.load(
-            key_cache_ptr + k_offset,
-            mask=dim_mask[:, None] & tile_mask[None, :],
-            other=0.0,
-        )
-        K, k_token_head_scales = _prepare_kv_tile(
-            K_load,
-            Q,
-            k_scale,
-            k_scale_cache_ptr,
-            physical_block_idx,
-            seq_offset,
-            kv_head_idx,
-            stride_ks_blk,
-            stride_ks_slot,
-            stride_ks_head,
-            tile_mask,
-            BLOCK_SIZE,
-            KV_QUANT_MODE,
-        )
+            k_offset = (
+                physical_block_idx[None, :] * stride_k_cache_0
+                + kv_head_idx * stride_k_cache_2
+                + offs_d[:, None] * stride_k_cache_3
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+            )
 
-        # V : (TILE_SIZE, HEAD_SIZE)
-        V_load = tl.load(
-            value_cache_ptr + v_offset,
-            mask=dim_mask[None, :] & tile_mask[:, None],
-            other=0.0,
-        )
-        V, v_token_head_scales = _prepare_kv_tile(
-            V_load,
-            Q,
-            v_scale,
-            v_scale_cache_ptr,
-            physical_block_idx,
-            seq_offset,
-            kv_head_idx,
-            stride_vs_blk,
-            stride_vs_slot,
-            stride_vs_head,
-            tile_mask,
-            BLOCK_SIZE,
-            KV_QUANT_MODE,
-        )
+            # K : (HEAD_SIZE, TILE_SIZE)
+            K_load = tl.load(
+                key_cache_ptr + k_offset,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0.0,
+            )
+            K, k_token_head_scales = _prepare_kv_tile(
+                K_load,
+                Q,
+                k_scale,
+                k_scale_cache_ptr,
+                physical_block_idx,
+                seq_offset,
+                kv_head_idx,
+                stride_ks_blk,
+                stride_ks_slot,
+                stride_ks_head,
+                tile_mask,
+                BLOCK_SIZE,
+                KV_QUANT_MODE,
+            )
+
+            # V : (TILE_SIZE, HEAD_SIZE)
+            V_load = tl.load(
+                value_cache_ptr + v_offset,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0.0,
+            )
+            V, v_token_head_scales = _prepare_kv_tile(
+                V_load,
+                Q,
+                v_scale,
+                v_scale_cache_ptr,
+                physical_block_idx,
+                seq_offset,
+                kv_head_idx,
+                stride_vs_blk,
+                stride_vs_slot,
+                stride_vs_head,
+                tile_mask,
+                BLOCK_SIZE,
+                KV_QUANT_MODE,
+            )
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -869,18 +1089,45 @@ def kernel_unified_attention_3d(
         else:
             acc += tl.dot(P.to(V.dtype), V)
 
-    segm_output_offset = (
-        query_offset_0[:, None].to(tl.int64)
-        * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-        + query_offset_1[:, None] * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-        + segm_idx * HEAD_SIZE_PADDED
-        + tl.arange(0, HEAD_SIZE_PADDED)[None, :]
-    )
-    tl.store(
-        segm_output_ptr + segm_output_offset,
-        acc,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
-    )
+    if USE_TD:
+        acc = acc.to(segm_output_ptr.dtype.element_ty)
+        segm_output_base = (
+            segm_output_ptr
+            + (cur_batch_in_all_start_index
+               + q_block_local_idx * BLOCK_Q).to(tl.int64)
+            * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+            + (kv_head_idx * num_queries_per_kv)
+            * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+            + segm_idx * HEAD_SIZE_PADDED
+        )
+        segm_output_desc = tl.make_tensor_descriptor(
+            base=segm_output_base,
+            shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
+            strides=(
+                num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
+                NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
+                1,
+            ),
+            block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        )
+        segm_output_desc.store(
+            [0, 0, 0],
+            acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        )
+    else:
+        segm_output_offset = (
+            query_offset_0[:, None].to(tl.int64)
+            * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+            + query_offset_1[:, None] * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+            + segm_idx * HEAD_SIZE_PADDED
+            + tl.arange(0, HEAD_SIZE_PADDED)[None, :]
+        )
+        tl.store(
+            segm_output_ptr + segm_output_offset,
+            acc,
+            mask=dim_mask[None, :] & query_mask_0[:, None]
+                 & query_mask_1[:, None],
+        )
     segm_offset = (
         query_offset_0.to(tl.int64) * (num_query_heads * NUM_SEGMENTS_PER_SEQ)
         + query_offset_1 * NUM_SEGMENTS_PER_SEQ
@@ -1046,6 +1293,11 @@ def unified_attention(
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE,
     k_scale_cache=None,  # [num_blocks, block_size, num_kv_heads] float32
     v_scale_cache=None,  # [num_blocks, block_size, num_kv_heads] float32
+    # Tensor descriptor mode: use tl.make_tensor_descriptor for Q/K/V/output.
+    # Enables HW 2D block reads on Intel Xe2/Xe3 and TMA on NVIDIA Hopper.
+    # The dead branch is eliminated at Triton compile time, so there is zero
+    # overhead when disabled.
+    use_td: bool = False,
 ):
     assert causal, "Only causal attention is supported"
     assert q_descale is None, "Q scales not supported"
@@ -1175,6 +1427,7 @@ def unified_attention(
             num_seqs=num_seqs,
             BLOCK_M=BLOCK_M,
             USE_FP8=output_scale is not None,
+            USE_TD=use_td,
             KV_QUANT_MODE=kv_quant_mode,
             k_scale_cache_ptr=k_scale_cache,
             v_scale_cache_ptr=v_scale_cache,
@@ -1236,6 +1489,7 @@ def unified_attention(
             num_seqs=num_seqs,
             BLOCK_M=BLOCK_M,
             NUM_SEGMENTS_PER_SEQ=num_par_softmax_segments,
+            USE_TD=use_td,
             KV_QUANT_MODE=kv_quant_mode,
             k_scale_cache_ptr=k_scale_cache,
             v_scale_cache_ptr=v_scale_cache,

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -108,28 +108,23 @@ def _load_q_td(
     """Load Q via tensor descriptor. Returns (BLOCK_M, HEAD_SIZE_PADDED)."""
     q_base = (
         query_ptr
-        + (cur_batch_in_all_start_index
-           + q_block_local_idx * BLOCK_Q) * query_stride_0
+        + (cur_batch_in_all_start_index + q_block_local_idx * BLOCK_Q) * query_stride_0
         + (kv_head_idx * num_queries_per_kv) * query_stride_1
     )
     if HEAD_SIZE == HEAD_SIZE_PADDED:
         q_desc = tl.make_tensor_descriptor(
             base=q_base,
-            shape=(q_block_local_len,
-                   num_queries_per_kv * HEAD_SIZE),
+            shape=(q_block_local_len, num_queries_per_kv * HEAD_SIZE),
             strides=(query_stride_0, 1),
-            block_shape=(BLOCK_Q,
-                         num_queries_per_kv * HEAD_SIZE_PADDED),
+            block_shape=(BLOCK_Q, num_queries_per_kv * HEAD_SIZE_PADDED),
         )
         return q_desc.load([0, 0]).reshape(BLOCK_M, HEAD_SIZE_PADDED)
     else:
         q_desc = tl.make_tensor_descriptor(
             base=q_base,
-            shape=(q_block_local_len,
-                   num_queries_per_kv, HEAD_SIZE),
+            shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
             strides=(query_stride_0, query_stride_1, 1),
-            block_shape=(BLOCK_Q,
-                         num_queries_per_kv, HEAD_SIZE_PADDED),
+            block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
         )
         return q_desc.load([0, 0, 0]).reshape(BLOCK_M, HEAD_SIZE_PADDED)
 
@@ -172,6 +167,128 @@ def _load_kv_tile_td(
     if IS_K:
         return tile.T
     return tile
+
+
+@triton.jit
+def _load_kv_tile_ptr(
+    cache_ptr,
+    physical_block_idx,
+    kv_head_idx,
+    seq_offset,
+    offs_d,
+    dim_mask,
+    tile_mask,
+    stride_cache_0: tl.int64,
+    stride_cache_1: tl.int64,
+    stride_cache_2: tl.int64,
+    stride_cache_3: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    IS_K: tl.constexpr,
+):
+    """Load a KV cache tile via pointer arithmetic.
+
+    Returns (HEAD_SIZE_PADDED, TILE_SIZE) for K or
+    (TILE_SIZE, HEAD_SIZE_PADDED) for V.
+    """
+    if IS_K:
+        k_offset = (
+            physical_block_idx[None, :] * stride_cache_0
+            + kv_head_idx * stride_cache_2
+            + offs_d[:, None] * stride_cache_3
+            + (seq_offset % BLOCK_SIZE)[None, :] * stride_cache_1
+        )
+        return tl.load(
+            cache_ptr + k_offset,
+            mask=dim_mask[:, None] & tile_mask[None, :],
+            other=0.0,
+        )
+    else:
+        v_offset = (
+            physical_block_idx[:, None] * stride_cache_0
+            + kv_head_idx * stride_cache_2
+            + offs_d[None, :] * stride_cache_3
+            + (seq_offset % BLOCK_SIZE)[:, None] * stride_cache_1
+        )
+        return tl.load(
+            cache_ptr + v_offset,
+            mask=dim_mask[None, :] & tile_mask[:, None],
+            other=0.0,
+        )
+
+
+@triton.jit
+def _store_output_2d_td(
+    output_ptr,
+    acc,
+    q_block_local_len,
+    cur_batch_in_all_start_index,
+    q_block_local_idx,
+    kv_head_idx,
+    num_queries_per_kv: tl.constexpr,
+    output_stride_0: tl.int64,
+    output_stride_1: tl.int64,
+    BLOCK_Q: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+):
+    """Store output via tensor descriptor for 2D kernel."""
+    acc = acc.to(output_ptr.dtype.element_ty)
+    output_base = (
+        output_ptr
+        + (cur_batch_in_all_start_index + q_block_local_idx * BLOCK_Q) * output_stride_0
+        + (kv_head_idx * num_queries_per_kv) * output_stride_1
+    )
+    output_desc = tl.make_tensor_descriptor(
+        base=output_base,
+        shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
+        strides=(output_stride_0, output_stride_1, 1),
+        block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+    )
+    output_desc.store(
+        [0, 0, 0],
+        acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+    )
+
+
+@triton.jit
+def _store_segm_output_3d_td(
+    segm_output_ptr,
+    acc,
+    q_block_local_len,
+    cur_batch_in_all_start_index,
+    q_block_local_idx,
+    kv_head_idx,
+    num_queries_per_kv: tl.constexpr,
+    segm_idx,
+    num_query_heads: tl.constexpr,
+    NUM_SEGMENTS_PER_SEQ: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+):
+    """Store segment output via tensor descriptor for 3D kernel."""
+    acc = acc.to(segm_output_ptr.dtype.element_ty)
+    segm_output_base = (
+        segm_output_ptr
+        + (cur_batch_in_all_start_index + q_block_local_idx * BLOCK_Q).to(tl.int64)
+        * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+        + (kv_head_idx * num_queries_per_kv) * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+        + segm_idx * HEAD_SIZE_PADDED
+    )
+    segm_output_desc = tl.make_tensor_descriptor(
+        base=segm_output_base,
+        shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
+        strides=(
+            num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
+            NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
+            1,
+        ),
+        block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+    )
+    segm_output_desc.store(
+        [0, 0, 0],
+        acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+    )
 
 
 @triton.jit
@@ -314,17 +431,23 @@ def kernel_unified_attention_2d(
     # Q : (BLOCK_M, HEAD_SIZE_PADDED)
     if USE_TD:
         Q = _load_q_td(
-            query_ptr, q_block_local_len,
-            query_stride_0, query_stride_1,
-            cur_batch_in_all_start_index, q_block_local_idx,
-            kv_head_idx, num_queries_per_kv,
-            BLOCK_Q, BLOCK_M, HEAD_SIZE, HEAD_SIZE_PADDED,
+            query_ptr,
+            q_block_local_len,
+            query_stride_0,
+            query_stride_1,
+            cur_batch_in_all_start_index,
+            q_block_local_idx,
+            kv_head_idx,
+            num_queries_per_kv,
+            BLOCK_Q,
+            BLOCK_M,
+            HEAD_SIZE,
+            HEAD_SIZE_PADDED,
         )
     else:
         Q = tl.load(
             query_ptr + query_offset,
-            mask=dim_mask[None, :] & query_mask_0[:, None]
-                 & query_mask_1[:, None],
+            mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
             other=0.0,
         )
 
@@ -416,97 +539,99 @@ def kernel_unified_attention_2d(
         ).to(tl.int64)
 
         if USE_TD:
-            # --- Tensor-descriptor path for K/V loads ---
-            # static_assert guarantees tile stays inside one physical block.
             offset_in_block = (j * TILE_SIZE) % BLOCK_SIZE
             K_load = _load_kv_tile_td(
-                key_cache_ptr, physical_block_idx[0], kv_head_idx,
+                key_cache_ptr,
+                physical_block_idx[0],
+                kv_head_idx,
                 offset_in_block,
-                stride_k_cache_0, stride_k_cache_1,
-                stride_k_cache_2, stride_k_cache_3,
-                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                stride_k_cache_0,
+                stride_k_cache_1,
+                stride_k_cache_2,
+                stride_k_cache_3,
+                BLOCK_SIZE,
+                TILE_SIZE,
+                HEAD_SIZE,
+                HEAD_SIZE_PADDED,
                 IS_K=True,
             )
             V_load = _load_kv_tile_td(
-                value_cache_ptr, physical_block_idx[0], kv_head_idx,
+                value_cache_ptr,
+                physical_block_idx[0],
+                kv_head_idx,
                 offset_in_block,
-                stride_v_cache_0, stride_v_cache_1,
-                stride_v_cache_2, stride_v_cache_3,
-                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                stride_v_cache_0,
+                stride_v_cache_1,
+                stride_v_cache_2,
+                stride_v_cache_3,
+                BLOCK_SIZE,
+                TILE_SIZE,
+                HEAD_SIZE,
+                HEAD_SIZE_PADDED,
+                IS_K=False,
+            )
+        else:
+            K_load = _load_kv_tile_ptr(
+                key_cache_ptr,
+                physical_block_idx,
+                kv_head_idx,
+                seq_offset,
+                offs_d,
+                dim_mask,
+                tile_mask,
+                stride_k_cache_0,
+                stride_k_cache_1,
+                stride_k_cache_2,
+                stride_k_cache_3,
+                BLOCK_SIZE,
+                IS_K=True,
+            )
+            V_load = _load_kv_tile_ptr(
+                value_cache_ptr,
+                physical_block_idx,
+                kv_head_idx,
+                seq_offset,
+                offs_d,
+                dim_mask,
+                tile_mask,
+                stride_v_cache_0,
+                stride_v_cache_1,
+                stride_v_cache_2,
+                stride_v_cache_3,
+                BLOCK_SIZE,
                 IS_K=False,
             )
 
-            K, k_token_head_scales = _prepare_kv_tile(
-                K_load, Q, k_scale, k_scale_cache_ptr,
-                physical_block_idx, seq_offset, kv_head_idx,
-                stride_ks_blk, stride_ks_slot, stride_ks_head,
-                tile_mask, BLOCK_SIZE, KV_QUANT_MODE,
-            )
-            V, v_token_head_scales = _prepare_kv_tile(
-                V_load, Q, v_scale, v_scale_cache_ptr,
-                physical_block_idx, seq_offset, kv_head_idx,
-                stride_vs_blk, stride_vs_slot, stride_vs_head,
-                tile_mask, BLOCK_SIZE, KV_QUANT_MODE,
-            )
-        else:
-            # --- Original pointer-arithmetic path for K/V loads ---
-            v_offset = (
-                physical_block_idx[:, None] * stride_v_cache_0
-                + kv_head_idx * stride_v_cache_2
-                + offs_d[None, :] * stride_v_cache_3
-                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
-            )
-
-            k_offset = (
-                physical_block_idx[None, :] * stride_k_cache_0
-                + kv_head_idx * stride_k_cache_2
-                + offs_d[:, None] * stride_k_cache_3
-                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
-            )
-
-            # K : (HEAD_SIZE, TILE_SIZE)
-            K_load = tl.load(
-                key_cache_ptr + k_offset,
-                mask=dim_mask[:, None] & tile_mask[None, :],
-                other=0.0,
-            )
-            K, k_token_head_scales = _prepare_kv_tile(
-                K_load,
-                Q,
-                k_scale,
-                k_scale_cache_ptr,
-                physical_block_idx,
-                seq_offset,
-                kv_head_idx,
-                stride_ks_blk,
-                stride_ks_slot,
-                stride_ks_head,
-                tile_mask,
-                BLOCK_SIZE,
-                KV_QUANT_MODE,
-            )
-
-            # V : (TILE_SIZE, HEAD_SIZE)
-            V_load = tl.load(
-                value_cache_ptr + v_offset,
-                mask=dim_mask[None, :] & tile_mask[:, None],
-                other=0.0,
-            )
-            V, v_token_head_scales = _prepare_kv_tile(
-                V_load,
-                Q,
-                v_scale,
-                v_scale_cache_ptr,
-                physical_block_idx,
-                seq_offset,
-                kv_head_idx,
-                stride_vs_blk,
-                stride_vs_slot,
-                stride_vs_head,
-                tile_mask,
-                BLOCK_SIZE,
-                KV_QUANT_MODE,
-            )
+        K, k_token_head_scales = _prepare_kv_tile(
+            K_load,
+            Q,
+            k_scale,
+            k_scale_cache_ptr,
+            physical_block_idx,
+            seq_offset,
+            kv_head_idx,
+            stride_ks_blk,
+            stride_ks_slot,
+            stride_ks_head,
+            tile_mask,
+            BLOCK_SIZE,
+            KV_QUANT_MODE,
+        )
+        V, v_token_head_scales = _prepare_kv_tile(
+            V_load,
+            Q,
+            v_scale,
+            v_scale_cache_ptr,
+            physical_block_idx,
+            seq_offset,
+            kv_head_idx,
+            stride_vs_blk,
+            stride_vs_slot,
+            stride_vs_head,
+            tile_mask,
+            BLOCK_SIZE,
+            KV_QUANT_MODE,
+        )
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -627,22 +752,19 @@ def kernel_unified_attention_2d(
         acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
 
     if USE_TD:
-        acc = acc.to(output_ptr.dtype.element_ty)
-        output_base = (
-            output_ptr
-            + (cur_batch_in_all_start_index
-               + q_block_local_idx * BLOCK_Q) * output_stride_0
-            + (kv_head_idx * num_queries_per_kv) * output_stride_1
-        )
-        output_desc = tl.make_tensor_descriptor(
-            base=output_base,
-            shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
-            strides=(output_stride_0, output_stride_1, 1),
-            block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
-        )
-        output_desc.store(
-            [0, 0, 0],
-            acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        _store_output_2d_td(
+            output_ptr,
+            acc,
+            q_block_local_len,
+            cur_batch_in_all_start_index,
+            q_block_local_idx,
+            kv_head_idx,
+            num_queries_per_kv,
+            output_stride_0,
+            output_stride_1,
+            BLOCK_Q,
+            HEAD_SIZE,
+            HEAD_SIZE_PADDED,
         )
     else:
         output_offset = (
@@ -654,8 +776,7 @@ def kernel_unified_attention_2d(
         tl.store(
             output_ptr + output_offset,
             acc,
-            mask=dim_mask[None, :] & query_mask_0[:, None]
-                 & query_mask_1[:, None],
+            mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
         )
 
 
@@ -785,17 +906,23 @@ def kernel_unified_attention_3d(
     # Q : (BLOCK_M, HEAD_SIZE_PADDED)
     if USE_TD:
         Q = _load_q_td(
-            query_ptr, q_block_local_len,
-            query_stride_0, query_stride_1,
-            cur_batch_in_all_start_index, q_block_local_idx,
-            kv_head_idx, num_queries_per_kv,
-            BLOCK_Q, BLOCK_M, HEAD_SIZE, HEAD_SIZE_PADDED,
+            query_ptr,
+            q_block_local_len,
+            query_stride_0,
+            query_stride_1,
+            cur_batch_in_all_start_index,
+            q_block_local_idx,
+            kv_head_idx,
+            num_queries_per_kv,
+            BLOCK_Q,
+            BLOCK_M,
+            HEAD_SIZE,
+            HEAD_SIZE_PADDED,
         )
     else:
         Q = tl.load(
             query_ptr + query_offset,
-            mask=dim_mask[None, :] & query_mask_0[:, None]
-                 & query_mask_1[:, None],
+            mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
             other=0.0,
         )
 
@@ -885,97 +1012,99 @@ def kernel_unified_attention_3d(
         ).to(tl.int64)
 
         if USE_TD:
-            # --- Tensor-descriptor path for K/V loads ---
-            # static_assert guarantees tile stays inside one physical block.
             offset_in_block = (j * TILE_SIZE) % BLOCK_SIZE
             K_load = _load_kv_tile_td(
-                key_cache_ptr, physical_block_idx[0], kv_head_idx,
+                key_cache_ptr,
+                physical_block_idx[0],
+                kv_head_idx,
                 offset_in_block,
-                stride_k_cache_0, stride_k_cache_1,
-                stride_k_cache_2, stride_k_cache_3,
-                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                stride_k_cache_0,
+                stride_k_cache_1,
+                stride_k_cache_2,
+                stride_k_cache_3,
+                BLOCK_SIZE,
+                TILE_SIZE,
+                HEAD_SIZE,
+                HEAD_SIZE_PADDED,
                 IS_K=True,
             )
             V_load = _load_kv_tile_td(
-                value_cache_ptr, physical_block_idx[0], kv_head_idx,
+                value_cache_ptr,
+                physical_block_idx[0],
+                kv_head_idx,
                 offset_in_block,
-                stride_v_cache_0, stride_v_cache_1,
-                stride_v_cache_2, stride_v_cache_3,
-                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                stride_v_cache_0,
+                stride_v_cache_1,
+                stride_v_cache_2,
+                stride_v_cache_3,
+                BLOCK_SIZE,
+                TILE_SIZE,
+                HEAD_SIZE,
+                HEAD_SIZE_PADDED,
+                IS_K=False,
+            )
+        else:
+            K_load = _load_kv_tile_ptr(
+                key_cache_ptr,
+                physical_block_idx,
+                kv_head_idx,
+                seq_offset,
+                offs_d,
+                dim_mask,
+                tile_mask,
+                stride_k_cache_0,
+                stride_k_cache_1,
+                stride_k_cache_2,
+                stride_k_cache_3,
+                BLOCK_SIZE,
+                IS_K=True,
+            )
+            V_load = _load_kv_tile_ptr(
+                value_cache_ptr,
+                physical_block_idx,
+                kv_head_idx,
+                seq_offset,
+                offs_d,
+                dim_mask,
+                tile_mask,
+                stride_v_cache_0,
+                stride_v_cache_1,
+                stride_v_cache_2,
+                stride_v_cache_3,
+                BLOCK_SIZE,
                 IS_K=False,
             )
 
-            K, k_token_head_scales = _prepare_kv_tile(
-                K_load, Q, k_scale, k_scale_cache_ptr,
-                physical_block_idx, seq_offset, kv_head_idx,
-                stride_ks_blk, stride_ks_slot, stride_ks_head,
-                tile_mask, BLOCK_SIZE, KV_QUANT_MODE,
-            )
-            V, v_token_head_scales = _prepare_kv_tile(
-                V_load, Q, v_scale, v_scale_cache_ptr,
-                physical_block_idx, seq_offset, kv_head_idx,
-                stride_vs_blk, stride_vs_slot, stride_vs_head,
-                tile_mask, BLOCK_SIZE, KV_QUANT_MODE,
-            )
-        else:
-            # --- Original pointer-arithmetic path for K/V loads ---
-            v_offset = (
-                physical_block_idx[:, None] * stride_v_cache_0
-                + kv_head_idx * stride_v_cache_2
-                + offs_d[None, :] * stride_v_cache_3
-                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
-            )
-
-            k_offset = (
-                physical_block_idx[None, :] * stride_k_cache_0
-                + kv_head_idx * stride_k_cache_2
-                + offs_d[:, None] * stride_k_cache_3
-                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
-            )
-
-            # K : (HEAD_SIZE, TILE_SIZE)
-            K_load = tl.load(
-                key_cache_ptr + k_offset,
-                mask=dim_mask[:, None] & tile_mask[None, :],
-                other=0.0,
-            )
-            K, k_token_head_scales = _prepare_kv_tile(
-                K_load,
-                Q,
-                k_scale,
-                k_scale_cache_ptr,
-                physical_block_idx,
-                seq_offset,
-                kv_head_idx,
-                stride_ks_blk,
-                stride_ks_slot,
-                stride_ks_head,
-                tile_mask,
-                BLOCK_SIZE,
-                KV_QUANT_MODE,
-            )
-
-            # V : (TILE_SIZE, HEAD_SIZE)
-            V_load = tl.load(
-                value_cache_ptr + v_offset,
-                mask=dim_mask[None, :] & tile_mask[:, None],
-                other=0.0,
-            )
-            V, v_token_head_scales = _prepare_kv_tile(
-                V_load,
-                Q,
-                v_scale,
-                v_scale_cache_ptr,
-                physical_block_idx,
-                seq_offset,
-                kv_head_idx,
-                stride_vs_blk,
-                stride_vs_slot,
-                stride_vs_head,
-                tile_mask,
-                BLOCK_SIZE,
-                KV_QUANT_MODE,
-            )
+        K, k_token_head_scales = _prepare_kv_tile(
+            K_load,
+            Q,
+            k_scale,
+            k_scale_cache_ptr,
+            physical_block_idx,
+            seq_offset,
+            kv_head_idx,
+            stride_ks_blk,
+            stride_ks_slot,
+            stride_ks_head,
+            tile_mask,
+            BLOCK_SIZE,
+            KV_QUANT_MODE,
+        )
+        V, v_token_head_scales = _prepare_kv_tile(
+            V_load,
+            Q,
+            v_scale,
+            v_scale_cache_ptr,
+            physical_block_idx,
+            seq_offset,
+            kv_head_idx,
+            stride_vs_blk,
+            stride_vs_slot,
+            stride_vs_head,
+            tile_mask,
+            BLOCK_SIZE,
+            KV_QUANT_MODE,
+        )
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -1090,29 +1219,20 @@ def kernel_unified_attention_3d(
             acc += tl.dot(P.to(V.dtype), V)
 
     if USE_TD:
-        acc = acc.to(segm_output_ptr.dtype.element_ty)
-        segm_output_base = (
-            segm_output_ptr
-            + (cur_batch_in_all_start_index
-               + q_block_local_idx * BLOCK_Q).to(tl.int64)
-            * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-            + (kv_head_idx * num_queries_per_kv)
-            * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-            + segm_idx * HEAD_SIZE_PADDED
-        )
-        segm_output_desc = tl.make_tensor_descriptor(
-            base=segm_output_base,
-            shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
-            strides=(
-                num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
-                NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
-                1,
-            ),
-            block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
-        )
-        segm_output_desc.store(
-            [0, 0, 0],
-            acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        _store_segm_output_3d_td(
+            segm_output_ptr,
+            acc,
+            q_block_local_len,
+            cur_batch_in_all_start_index,
+            q_block_local_idx,
+            kv_head_idx,
+            num_queries_per_kv,
+            segm_idx,
+            num_query_heads,
+            NUM_SEGMENTS_PER_SEQ,
+            BLOCK_Q,
+            HEAD_SIZE,
+            HEAD_SIZE_PADDED,
         )
     else:
         segm_output_offset = (
@@ -1125,8 +1245,7 @@ def kernel_unified_attention_3d(
         tl.store(
             segm_output_ptr + segm_output_offset,
             acc,
-            mask=dim_mask[None, :] & query_mask_0[:, None]
-                 & query_mask_1[:, None],
+            mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
         )
     segm_offset = (
         query_offset_0.to(tl.int64) * (num_query_heads * NUM_SEGMENTS_PER_SEQ)


### PR DESCRIPTION
## Summary

Add a `USE_TD: tl.constexpr` flag to both `kernel_unified_attention_2d` and `kernel_unified_attention_3d` in the Triton unified attention backend. When enabled, Q/K/V loads and output stores use `tl.make_tensor_descriptor` (HW 2D block reads on Intel Xe2/Xe3). The dead branch is eliminated at Triton compile time, so NVIDIA/AMD see zero overhead.

## Changes

### `vllm/v1/attention/ops/triton_unified_attention.py`
- **`_load_q_td()`** — helper: loads Q tensor via 2D/3D tensor descriptor, handles `HEAD_SIZE == HEAD_SIZE_PADDED` branching
- **`_load_kv_tile_td()`** — helper: loads K or V cache tile via descriptor, transposes K when `IS_K=True`, uses `shape=HEAD_SIZE` with `block_shape=HEAD_SIZE_PADDED` for automatic zero-padding
- Both 2D and 3D kernels: `USE_TD: tl.constexpr = False` parameter, `tl.static_assert(BLOCK_SIZE % TILE_SIZE == 0)` guard
- `unified_attention()` wrapper: accepts `use_td: bool = False`, passes to kernels

### `vllm/v1/attention/backends/triton_attn.py`
- Auto-detect: `self.use_td = current_platform.is_xpu()`
- Override via `VLLM_TRITON_USE_TD` env var (registered in `vllm/envs.py`)

### `vllm/envs.py`
- Register `VLLM_TRITON_USE_TD`: `None` = auto-detect, `True`/`False` = explicit override

## Context
Implements Whitney Tsang's proposed approach from the B200 regression analysis of PR #35401. Instead of a separate backend (`TRITON_ATTN_TD`), this integrates TD support directly into the existing kernel with compile-time dispatch.

## TODO
- [ ] XPU hardware testing (BMG)
- [ ] Performance benchmarks vs pointer path
- [ ] `num_stages` tuning for B200 (sm_100)