### PR TITLE
attention: add USE_TD constexpr for tensor descriptor Q/K/V load/store

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -76,6 +76,7 @@ if TYPE_CHECKING:
     VLLM_MAIN_CUDA_VERSION: str = "12.9"
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
     VLLM_BATCH_INVARIANT: bool = False
+    VLLM_TRITON_USE_TD: bool | None = None
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
     VLLM_USE_PRECOMPILED: bool = False
@@ -501,6 +502,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable batch-invariant mode: deterministic results regardless of
     # batch composition. Requires NVIDIA GPU with compute capability >= 9.0.
     "VLLM_BATCH_INVARIANT": lambda: bool(int(os.getenv("VLLM_BATCH_INVARIANT", "0"))),
+    # Use tensor descriptors in Triton unified attention.
+    # None = auto-detect (XPU → True, else False). Set 1/0 to override.
+    "VLLM_TRITON_USE_TD":
+    lambda: {"1": True, "0": False}.get(os.getenv("VLLM_TRITON_USE_TD", "").strip()),
     # Maximum number of compilation jobs to run in parallel.
     # By default this is the number of CPUs
     "MAX_JOBS": lambda: os.getenv("MAX_JOBS", None),

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -408,6 +408,17 @@ class TritonAttentionImpl(AttentionImpl):
         self.use_alibi_sqrt = use_alibi_sqrt
         self.supports_quant_query_input = current_platform.is_cuda()
 
+        # Enable tensor descriptors for Q/K/V load/store on platforms that
+        # benefit from HW 2D block reads (Intel Xe2/Xe3).  The dead branch
+        # is eliminated at Triton compile time, so NVIDIA/AMD see zero cost.
+        # Override with VLLM_TRITON_USE_TD=1/0 for benchmarking.
+        import vllm.envs as envs
+        td_override = envs.VLLM_TRITON_USE_TD
+        if td_override is not None:
+            self.use_td = td_override
+        else:
+            self.use_td = current_platform.is_xpu()
+
     def forward(
         self,
         layer: torch.nn.Module,
@@ -522,6 +533,7 @@ class TritonAttentionImpl(AttentionImpl):
             sinks=self.sinks,
             output_scale=output_scale,
             mm_prefix_range=mm_prefix_range_tensor,
+            use_td=self.use_td,
         )
 
         return output

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -117,6 +117,131 @@ def _load_kv_tile_td(
 
 
 @triton.jit
+def _load_kv_tile_ptr(
+    cache_ptr,
+    physical_block_idx,
+    kv_head_idx,
+    seq_offset,
+    offs_d,
+    dim_mask,
+    tile_mask,
+    stride_cache_0: tl.int64,
+    stride_cache_1: tl.int64,
+    stride_cache_2: tl.int64,
+    stride_cache_3: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    IS_K: tl.constexpr,
+):
+    """Load a KV cache tile via pointer arithmetic.
+
+    Returns (HEAD_SIZE_PADDED, TILE_SIZE) for K or
+    (TILE_SIZE, HEAD_SIZE_PADDED) for V.
+    """
+    if IS_K:
+        k_offset = (
+            physical_block_idx[None, :] * stride_cache_0
+            + kv_head_idx * stride_cache_2
+            + offs_d[:, None] * stride_cache_3
+            + (seq_offset % BLOCK_SIZE)[None, :] * stride_cache_1
+        )
+        return tl.load(
+            cache_ptr + k_offset,
+            mask=dim_mask[:, None] & tile_mask[None, :],
+            other=0.0,
+        )
+    else:
+        v_offset = (
+            physical_block_idx[:, None] * stride_cache_0
+            + kv_head_idx * stride_cache_2
+            + offs_d[None, :] * stride_cache_3
+            + (seq_offset % BLOCK_SIZE)[:, None] * stride_cache_1
+        )
+        return tl.load(
+            cache_ptr + v_offset,
+            mask=dim_mask[None, :] & tile_mask[:, None],
+            other=0.0,
+        )
+
+
+@triton.jit
+def _store_output_2d_td(
+    output_ptr,
+    acc,
+    q_block_local_len,
+    cur_batch_in_all_start_index,
+    q_block_local_idx,
+    kv_head_idx,
+    num_queries_per_kv: tl.constexpr,
+    output_stride_0: tl.int64,
+    output_stride_1: tl.int64,
+    BLOCK_Q: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+):
+    """Store output via tensor descriptor for 2D kernel."""
+    acc = acc.to(output_ptr.dtype.element_ty)
+    output_base = (
+        output_ptr
+        + (cur_batch_in_all_start_index
+           + q_block_local_idx * BLOCK_Q) * output_stride_0
+        + (kv_head_idx * num_queries_per_kv) * output_stride_1
+    )
+    output_desc = tl.make_tensor_descriptor(
+        base=output_base,
+        shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
+        strides=(output_stride_0, output_stride_1, 1),
+        block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+    )
+    output_desc.store(
+        [0, 0, 0],
+        acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+    )
+
+
+@triton.jit
+def _store_segm_output_3d_td(
+    segm_output_ptr,
+    acc,
+    q_block_local_len,
+    cur_batch_in_all_start_index,
+    q_block_local_idx,
+    kv_head_idx,
+    num_queries_per_kv: tl.constexpr,
+    segm_idx,
+    num_query_heads: tl.constexpr,
+    NUM_SEGMENTS_PER_SEQ: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+):
+    """Store segment output via tensor descriptor for 3D kernel."""
+    acc = acc.to(segm_output_ptr.dtype.element_ty)
+    segm_output_base = (
+        segm_output_ptr
+        + (cur_batch_in_all_start_index
+           + q_block_local_idx * BLOCK_Q).to(tl.int64)
+        * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+        + (kv_head_idx * num_queries_per_kv)
+        * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+        + segm_idx * HEAD_SIZE_PADDED
+    )
+    segm_output_desc = tl.make_tensor_descriptor(
+        base=segm_output_base,
+        shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
+        strides=(
+            num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
+            NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
+            1,
+        ),
+        block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+    )
+    segm_output_desc.store(
+        [0, 0, 0],
+        acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+    )
+
+
+@triton.jit
 def find_seq_idx(
     query_start_len_ptr,
     target_idx,
@@ -346,8 +471,6 @@ def kernel_unified_attention_2d(
         ).to(tl.int64)
 
         if USE_TD:
-            # --- Tensor-descriptor path for K/V loads ---
-            # static_assert guarantees tile stays inside one physical block.
             offset_in_block = (j * TILE_SIZE) % BLOCK_SIZE
             K_load = _load_kv_tile_td(
                 key_cache_ptr, physical_block_idx[0], kv_head_idx,
@@ -365,67 +488,39 @@ def kernel_unified_attention_2d(
                 BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
                 IS_K=False,
             )
-
-            if K_load.dtype.is_fp8():
-                if Q.dtype.is_fp8():
-                    K = K_load
-                else:
-                    K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
-            else:
-                K = K_load
-
-            if V_load.dtype.is_fp8():
-                if Q.dtype.is_fp8():
-                    V = V_load
-                else:
-                    V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
-            else:
-                V = V_load
         else:
-            # --- Original pointer-arithmetic path for K/V loads ---
-            v_offset = (
-                physical_block_idx[:, None] * stride_v_cache_0
-                + kv_head_idx * stride_v_cache_2
-                + offs_d[None, :] * stride_v_cache_3
-                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            K_load = _load_kv_tile_ptr(
+                key_cache_ptr, physical_block_idx, kv_head_idx,
+                seq_offset, offs_d, dim_mask, tile_mask,
+                stride_k_cache_0, stride_k_cache_1,
+                stride_k_cache_2, stride_k_cache_3,
+                BLOCK_SIZE, IS_K=True,
+            )
+            V_load = _load_kv_tile_ptr(
+                value_cache_ptr, physical_block_idx, kv_head_idx,
+                seq_offset, offs_d, dim_mask, tile_mask,
+                stride_v_cache_0, stride_v_cache_1,
+                stride_v_cache_2, stride_v_cache_3,
+                BLOCK_SIZE, IS_K=False,
             )
 
-            k_offset = (
-                physical_block_idx[None, :] * stride_k_cache_0
-                + kv_head_idx * stride_k_cache_2
-                + offs_d[:, None] * stride_k_cache_3
-                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
-            )
-
-            # K : (HEAD_SIZE, TILE_SIZE)
-            K_load = tl.load(
-                key_cache_ptr + k_offset,
-                mask=dim_mask[:, None] & tile_mask[None, :],
-                other=0.0,
-            )
-
-            if K_load.dtype.is_fp8():
-                if Q.dtype.is_fp8():
-                    K = K_load
-                else:
-                    K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
-            else:
+        # K : (HEAD_SIZE_PADDED, TILE_SIZE)
+        if K_load.dtype.is_fp8():
+            if Q.dtype.is_fp8():
                 K = K_load
-
-            # V : (TILE_SIZE, HEAD_SIZE)
-            V_load = tl.load(
-                value_cache_ptr + v_offset,
-                mask=dim_mask[None, :] & tile_mask[:, None],
-                other=0.0,
-            )
-
-            if V_load.dtype.is_fp8():
-                if Q.dtype.is_fp8():
-                    V = V_load
-                else:
-                    V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
             else:
+                K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
+        else:
+            K = K_load
+
+        # V : (TILE_SIZE, HEAD_SIZE_PADDED)
+        if V_load.dtype.is_fp8():
+            if Q.dtype.is_fp8():
                 V = V_load
+            else:
+                V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
+        else:
+            V = V_load
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -536,22 +631,12 @@ def kernel_unified_attention_2d(
         acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
 
     if USE_TD:
-        acc = acc.to(output_ptr.dtype.element_ty)
-        output_base = (
-            output_ptr
-            + (cur_batch_in_all_start_index
-               + q_block_local_idx * BLOCK_Q) * output_stride_0
-            + (kv_head_idx * num_queries_per_kv) * output_stride_1
-        )
-        output_desc = tl.make_tensor_descriptor(
-            base=output_base,
-            shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
-            strides=(output_stride_0, output_stride_1, 1),
-            block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
-        )
-        output_desc.store(
-            [0, 0, 0],
-            acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        _store_output_2d_td(
+            output_ptr, acc, q_block_local_len,
+            cur_batch_in_all_start_index, q_block_local_idx,
+            kv_head_idx, num_queries_per_kv,
+            output_stride_0, output_stride_1,
+            BLOCK_Q, HEAD_SIZE, HEAD_SIZE_PADDED,
         )
     else:
         output_offset = (
@@ -782,8 +867,6 @@ def kernel_unified_attention_3d(
         ).to(tl.int64)
 
         if USE_TD:
-            # --- Tensor-descriptor path for K/V loads ---
-            # static_assert guarantees tile stays inside one physical block.
             offset_in_block = (j * TILE_SIZE) % BLOCK_SIZE
             K_load = _load_kv_tile_td(
                 key_cache_ptr, physical_block_idx[0], kv_head_idx,
@@ -801,67 +884,39 @@ def kernel_unified_attention_3d(
                 BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
                 IS_K=False,
             )
-
-            if K_load.dtype.is_fp8():
-                if Q.dtype.is_fp8():
-                    K = K_load
-                else:
-                    K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
-            else:
-                K = K_load
-
-            if V_load.dtype.is_fp8():
-                if Q.dtype.is_fp8():
-                    V = V_load
-                else:
-                    V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
-            else:
-                V = V_load
         else:
-            # --- Original pointer-arithmetic path for K/V loads ---
-            v_offset = (
-                physical_block_idx[:, None] * stride_v_cache_0
-                + kv_head_idx * stride_v_cache_2
-                + offs_d[None, :] * stride_v_cache_3
-                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            K_load = _load_kv_tile_ptr(
+                key_cache_ptr, physical_block_idx, kv_head_idx,
+                seq_offset, offs_d, dim_mask, tile_mask,
+                stride_k_cache_0, stride_k_cache_1,
+                stride_k_cache_2, stride_k_cache_3,
+                BLOCK_SIZE, IS_K=True,
+            )
+            V_load = _load_kv_tile_ptr(
+                value_cache_ptr, physical_block_idx, kv_head_idx,
+                seq_offset, offs_d, dim_mask, tile_mask,
+                stride_v_cache_0, stride_v_cache_1,
+                stride_v_cache_2, stride_v_cache_3,
+                BLOCK_SIZE, IS_K=False,
             )
 
-            k_offset = (
-                physical_block_idx[None, :] * stride_k_cache_0
-                + kv_head_idx * stride_k_cache_2
-                + offs_d[:, None] * stride_k_cache_3
-                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
-            )
-
-            # K : (HEAD_SIZE, TILE_SIZE)
-            K_load = tl.load(
-                key_cache_ptr + k_offset,
-                mask=dim_mask[:, None] & tile_mask[None, :],
-                other=0.0,
-            )
-
-            if K_load.dtype.is_fp8():
-                if Q.dtype.is_fp8():
-                    K = K_load
-                else:
-                    K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
-            else:
+        # K : (HEAD_SIZE_PADDED, TILE_SIZE)
+        if K_load.dtype.is_fp8():
+            if Q.dtype.is_fp8():
                 K = K_load
-
-            # V : (TILE_SIZE, HEAD_SIZE)
-            V_load = tl.load(
-                value_cache_ptr + v_offset,
-                mask=dim_mask[None, :] & tile_mask[:, None],
-                other=0.0,
-            )
-
-            if V_load.dtype.is_fp8():
-                if Q.dtype.is_fp8():
-                    V = V_load
-                else:
-                    V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
             else:
+                K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
+        else:
+            K = K_load
+
+        # V : (TILE_SIZE, HEAD_SIZE_PADDED)
+        if V_load.dtype.is_fp8():
+            if Q.dtype.is_fp8():
                 V = V_load
+            else:
+                V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
+        else:
+            V = V_load
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -965,29 +1020,12 @@ def kernel_unified_attention_3d(
         acc += tl.dot(P.to(V.dtype), V)
 
     if USE_TD:
-        acc = acc.to(segm_output_ptr.dtype.element_ty)
-        segm_output_base = (
-            segm_output_ptr
-            + (cur_batch_in_all_start_index
-               + q_block_local_idx * BLOCK_Q).to(tl.int64)
-            * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-            + (kv_head_idx * num_queries_per_kv)
-            * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-            + segm_idx * HEAD_SIZE_PADDED
-        )
-        segm_output_desc = tl.make_tensor_descriptor(
-            base=segm_output_base,
-            shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
-            strides=(
-                num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
-                NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
-                1,
-            ),
-            block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
-        )
-        segm_output_desc.store(
-            [0, 0, 0],
-            acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        _store_segm_output_3d_td(
+            segm_output_ptr, acc, q_block_local_len,
+            cur_batch_in_all_start_index, q_block_local_idx,
+            kv_head_idx, num_queries_per_kv, segm_idx,
+            num_query_heads, NUM_SEGMENTS_PER_SEQ,
+            BLOCK_Q, HEAD_SIZE, HEAD_SIZE_PADDED,
         )
     else:
         segm_output_offset = (

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -33,6 +33,90 @@ def apply_softcap(S, x):
 
 
 @triton.jit
+def _load_q_td(
+    query_ptr,
+    q_block_local_len,
+    query_stride_0: tl.int64,
+    query_stride_1: tl.int64,
+    cur_batch_in_all_start_index,
+    q_block_local_idx,
+    kv_head_idx,
+    num_queries_per_kv: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+):
+    """Load Q via tensor descriptor. Returns (BLOCK_M, HEAD_SIZE_PADDED)."""
+    q_base = (
+        query_ptr
+        + (cur_batch_in_all_start_index
+           + q_block_local_idx * BLOCK_Q) * query_stride_0
+        + (kv_head_idx * num_queries_per_kv) * query_stride_1
+    )
+    if HEAD_SIZE == HEAD_SIZE_PADDED:
+        q_desc = tl.make_tensor_descriptor(
+            base=q_base,
+            shape=(q_block_local_len,
+                   num_queries_per_kv * HEAD_SIZE),
+            strides=(query_stride_0, 1),
+            block_shape=(BLOCK_Q,
+                         num_queries_per_kv * HEAD_SIZE_PADDED),
+        )
+        return q_desc.load([0, 0]).reshape(BLOCK_M, HEAD_SIZE_PADDED)
+    else:
+        q_desc = tl.make_tensor_descriptor(
+            base=q_base,
+            shape=(q_block_local_len,
+                   num_queries_per_kv, HEAD_SIZE),
+            strides=(query_stride_0, query_stride_1, 1),
+            block_shape=(BLOCK_Q,
+                         num_queries_per_kv, HEAD_SIZE_PADDED),
+        )
+        return q_desc.load([0, 0, 0]).reshape(BLOCK_M, HEAD_SIZE_PADDED)
+
+
+@triton.jit
+def _load_kv_tile_td(
+    cache_ptr,
+    physical_block_idx_scalar,
+    kv_head_idx,
+    offset_in_block,
+    stride_cache_0: tl.int64,
+    stride_cache_1: tl.int64,
+    stride_cache_2: tl.int64,
+    stride_cache_3: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    TILE_SIZE: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+    IS_K: tl.constexpr,
+):
+    """Load a KV cache tile via tensor descriptor.
+
+    Returns (TILE_SIZE, HEAD_SIZE_PADDED) for V or
+    (HEAD_SIZE_PADDED, TILE_SIZE) for K (transposed).
+    Tensor descriptors zero-pad reads beyond the shape boundary,
+    so HEAD_SIZE_PADDED > HEAD_SIZE is handled correctly.
+    """
+    base = (
+        cache_ptr
+        + physical_block_idx_scalar * stride_cache_0
+        + kv_head_idx * stride_cache_2
+    )
+    desc = tl.make_tensor_descriptor(
+        base=base,
+        shape=(BLOCK_SIZE, HEAD_SIZE),
+        strides=(stride_cache_1, stride_cache_3),
+        block_shape=(TILE_SIZE, HEAD_SIZE_PADDED),
+    )
+    tile = desc.load([offset_in_block, 0])
+    if IS_K:
+        return tile.T
+    return tile
+
+
+@triton.jit
 def find_seq_idx(
     query_start_len_ptr,
     target_idx,
@@ -105,6 +189,7 @@ def kernel_unified_attention_2d(
     num_seqs: tl.int32,
     BLOCK_M: tl.constexpr,  # int
     USE_FP8: tl.constexpr,  # bool
+    USE_TD: tl.constexpr = False,  # Use tensor descriptors for load/store
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
 ):
@@ -127,6 +212,18 @@ def kernel_unified_attention_2d(
     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
         return
 
+    if USE_TD:
+        tl.static_assert(
+            BLOCK_SIZE % TILE_SIZE == 0,
+            "USE_TD requires BLOCK_SIZE to be a multiple of TILE_SIZE",
+        )
+
+    # Number of valid query rows in this block (used by TD path for
+    # descriptor shapes, but always computed to keep variable in scope).
+    q_block_local_len = tl.minimum(
+        BLOCK_Q, cur_batch_query_len - q_block_local_idx * BLOCK_Q
+    )
+
     offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
     offs_t = tl.arange(0, TILE_SIZE)
@@ -145,11 +242,21 @@ def kernel_unified_attention_2d(
     query_mask_1 = tl.where(query_offset_1 < num_query_heads, 1, 0).to(tl.int1)
 
     # Q : (BLOCK_M, HEAD_SIZE_PADDED)
-    Q = tl.load(
-        query_ptr + query_offset,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
-        other=0.0,
-    )
+    if USE_TD:
+        Q = _load_q_td(
+            query_ptr, q_block_local_len,
+            query_stride_0, query_stride_1,
+            cur_batch_in_all_start_index, q_block_local_idx,
+            kv_head_idx, num_queries_per_kv,
+            BLOCK_Q, BLOCK_M, HEAD_SIZE, HEAD_SIZE_PADDED,
+        )
+    else:
+        Q = tl.load(
+            query_ptr + query_offset,
+            mask=dim_mask[None, :] & query_mask_0[:, None]
+                 & query_mask_1[:, None],
+            other=0.0,
+        )
 
     block_table_offset = seq_idx * block_table_stride
 
@@ -238,49 +345,87 @@ def kernel_unified_attention_2d(
             block_tables_ptr + block_table_offset + seq_offset // BLOCK_SIZE
         ).to(tl.int64)
 
-        v_offset = (
-            physical_block_idx[:, None] * stride_v_cache_0
-            + kv_head_idx * stride_v_cache_2
-            + offs_d[None, :] * stride_v_cache_3
-            + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
-        )
+        if USE_TD:
+            # --- Tensor-descriptor path for K/V loads ---
+            # static_assert guarantees tile stays inside one physical block.
+            offset_in_block = (j * TILE_SIZE) % BLOCK_SIZE
+            K_load = _load_kv_tile_td(
+                key_cache_ptr, physical_block_idx[0], kv_head_idx,
+                offset_in_block,
+                stride_k_cache_0, stride_k_cache_1,
+                stride_k_cache_2, stride_k_cache_3,
+                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                IS_K=True,
+            )
+            V_load = _load_kv_tile_td(
+                value_cache_ptr, physical_block_idx[0], kv_head_idx,
+                offset_in_block,
+                stride_v_cache_0, stride_v_cache_1,
+                stride_v_cache_2, stride_v_cache_3,
+                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                IS_K=False,
+            )
 
-        k_offset = (
-            physical_block_idx[None, :] * stride_k_cache_0
-            + kv_head_idx * stride_k_cache_2
-            + offs_d[:, None] * stride_k_cache_3
-            + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
-        )
-
-        # K : (HEAD_SIZE, TILE_SIZE)
-        K_load = tl.load(
-            key_cache_ptr + k_offset,
-            mask=dim_mask[:, None] & tile_mask[None, :],
-            other=0.0,
-        )
-
-        if K_load.dtype.is_fp8():
-            if Q.dtype.is_fp8():
+            if K_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    K = K_load
+                else:
+                    K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
+            else:
                 K = K_load
+
+            if V_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    V = V_load
+                else:
+                    V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
             else:
-                K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
-        else:
-            K = K_load
-
-        # V : (TILE_SIZE, HEAD_SIZE)
-        V_load = tl.load(
-            value_cache_ptr + v_offset,
-            mask=dim_mask[None, :] & tile_mask[:, None],
-            other=0.0,
-        )
-
-        if V_load.dtype.is_fp8():
-            if Q.dtype.is_fp8():
                 V = V_load
-            else:
-                V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
         else:
-            V = V_load
+            # --- Original pointer-arithmetic path for K/V loads ---
+            v_offset = (
+                physical_block_idx[:, None] * stride_v_cache_0
+                + kv_head_idx * stride_v_cache_2
+                + offs_d[None, :] * stride_v_cache_3
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            )
+
+            k_offset = (
+                physical_block_idx[None, :] * stride_k_cache_0
+                + kv_head_idx * stride_k_cache_2
+                + offs_d[:, None] * stride_k_cache_3
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+            )
+
+            # K : (HEAD_SIZE, TILE_SIZE)
+            K_load = tl.load(
+                key_cache_ptr + k_offset,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0.0,
+            )
+
+            if K_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    K = K_load
+                else:
+                    K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
+            else:
+                K = K_load
+
+            # V : (TILE_SIZE, HEAD_SIZE)
+            V_load = tl.load(
+                value_cache_ptr + v_offset,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0.0,
+            )
+
+            if V_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    V = V_load
+                else:
+                    V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
+            else:
+                V = V_load
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -390,17 +535,37 @@ def kernel_unified_attention_2d(
         acc = acc * tl.load(out_scale)
         acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
 
-    output_offset = (
-        query_offset_0[:, None] * output_stride_0
-        + query_offset_1[:, None] * output_stride_1
-        + offs_d[None, :]
-    )
+    if USE_TD:
+        acc = acc.to(output_ptr.dtype.element_ty)
+        output_base = (
+            output_ptr
+            + (cur_batch_in_all_start_index
+               + q_block_local_idx * BLOCK_Q) * output_stride_0
+            + (kv_head_idx * num_queries_per_kv) * output_stride_1
+        )
+        output_desc = tl.make_tensor_descriptor(
+            base=output_base,
+            shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
+            strides=(output_stride_0, output_stride_1, 1),
+            block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        )
+        output_desc.store(
+            [0, 0, 0],
+            acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        )
+    else:
+        output_offset = (
+            query_offset_0[:, None] * output_stride_0
+            + query_offset_1[:, None] * output_stride_1
+            + offs_d[None, :]
+        )
 
-    tl.store(
-        output_ptr + output_offset,
-        acc,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
-    )
+        tl.store(
+            output_ptr + output_offset,
+            acc,
+            mask=dim_mask[None, :] & query_mask_0[:, None]
+                 & query_mask_1[:, None],
+        )
 
 
 @triton.jit
@@ -453,6 +618,7 @@ def kernel_unified_attention_3d(
     USE_MM_PREFIX: tl.constexpr,  # bool
     MAX_MM_RANGES: tl.constexpr,  # int
     mm_prefix_range_ptr,  # [num_seqs] - prefix length for each sequence
+    USE_TD: tl.constexpr = False,  # Use tensor descriptors for load/store
 ):
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -474,6 +640,12 @@ def kernel_unified_attention_3d(
     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
         return
 
+    if USE_TD:
+        tl.static_assert(
+            BLOCK_SIZE % TILE_SIZE == 0,
+            "USE_TD requires BLOCK_SIZE to be a multiple of TILE_SIZE",
+        )
+
     # sequence len for this particular sequence
     seq_len = tl.load(seq_lens_ptr + seq_idx)
 
@@ -483,6 +655,12 @@ def kernel_unified_attention_3d(
 
     if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
         return
+
+    # Number of valid query rows in this block (used by TD path for
+    # descriptor shapes, but always computed to keep variable in scope).
+    q_block_local_len = tl.minimum(
+        BLOCK_Q, cur_batch_query_len - q_block_local_idx * BLOCK_Q
+    )
 
     offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
@@ -502,11 +680,21 @@ def kernel_unified_attention_3d(
     query_mask_1 = tl.where(query_offset_1 < num_query_heads, 1, 0).to(tl.int1)
 
     # Q : (BLOCK_M, HEAD_SIZE_PADDED)
-    Q = tl.load(
-        query_ptr + query_offset,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
-        other=0.0,
-    )
+    if USE_TD:
+        Q = _load_q_td(
+            query_ptr, q_block_local_len,
+            query_stride_0, query_stride_1,
+            cur_batch_in_all_start_index, q_block_local_idx,
+            kv_head_idx, num_queries_per_kv,
+            BLOCK_Q, BLOCK_M, HEAD_SIZE, HEAD_SIZE_PADDED,
+        )
+    else:
+        Q = tl.load(
+            query_ptr + query_offset,
+            mask=dim_mask[None, :] & query_mask_0[:, None]
+                 & query_mask_1[:, None],
+            other=0.0,
+        )
 
     block_table_offset = seq_idx * block_table_stride
 
@@ -593,49 +781,87 @@ def kernel_unified_attention_3d(
             block_tables_ptr + block_table_offset + seq_offset // BLOCK_SIZE
         ).to(tl.int64)
 
-        v_offset = (
-            physical_block_idx[:, None] * stride_v_cache_0
-            + kv_head_idx * stride_v_cache_2
-            + offs_d[None, :] * stride_v_cache_3
-            + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
-        )
+        if USE_TD:
+            # --- Tensor-descriptor path for K/V loads ---
+            # static_assert guarantees tile stays inside one physical block.
+            offset_in_block = (j * TILE_SIZE) % BLOCK_SIZE
+            K_load = _load_kv_tile_td(
+                key_cache_ptr, physical_block_idx[0], kv_head_idx,
+                offset_in_block,
+                stride_k_cache_0, stride_k_cache_1,
+                stride_k_cache_2, stride_k_cache_3,
+                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                IS_K=True,
+            )
+            V_load = _load_kv_tile_td(
+                value_cache_ptr, physical_block_idx[0], kv_head_idx,
+                offset_in_block,
+                stride_v_cache_0, stride_v_cache_1,
+                stride_v_cache_2, stride_v_cache_3,
+                BLOCK_SIZE, TILE_SIZE, HEAD_SIZE, HEAD_SIZE_PADDED,
+                IS_K=False,
+            )
 
-        k_offset = (
-            physical_block_idx[None, :] * stride_k_cache_0
-            + kv_head_idx * stride_k_cache_2
-            + offs_d[:, None] * stride_k_cache_3
-            + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
-        )
-
-        # K : (HEAD_SIZE, TILE_SIZE)
-        K_load = tl.load(
-            key_cache_ptr + k_offset,
-            mask=dim_mask[:, None] & tile_mask[None, :],
-            other=0.0,
-        )
-
-        if K_load.dtype.is_fp8():
-            if Q.dtype.is_fp8():
+            if K_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    K = K_load
+                else:
+                    K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
+            else:
                 K = K_load
+
+            if V_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    V = V_load
+                else:
+                    V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
             else:
-                K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
-        else:
-            K = K_load
-
-        # V : (TILE_SIZE, HEAD_SIZE)
-        V_load = tl.load(
-            value_cache_ptr + v_offset,
-            mask=dim_mask[None, :] & tile_mask[:, None],
-            other=0.0,
-        )
-
-        if V_load.dtype.is_fp8():
-            if Q.dtype.is_fp8():
                 V = V_load
-            else:
-                V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
         else:
-            V = V_load
+            # --- Original pointer-arithmetic path for K/V loads ---
+            v_offset = (
+                physical_block_idx[:, None] * stride_v_cache_0
+                + kv_head_idx * stride_v_cache_2
+                + offs_d[None, :] * stride_v_cache_3
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            )
+
+            k_offset = (
+                physical_block_idx[None, :] * stride_k_cache_0
+                + kv_head_idx * stride_k_cache_2
+                + offs_d[:, None] * stride_k_cache_3
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+            )
+
+            # K : (HEAD_SIZE, TILE_SIZE)
+            K_load = tl.load(
+                key_cache_ptr + k_offset,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0.0,
+            )
+
+            if K_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    K = K_load
+                else:
+                    K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
+            else:
+                K = K_load
+
+            # V : (TILE_SIZE, HEAD_SIZE)
+            V_load = tl.load(
+                value_cache_ptr + v_offset,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0.0,
+            )
+
+            if V_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    V = V_load
+                else:
+                    V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
+            else:
+                V = V_load
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -738,18 +964,45 @@ def kernel_unified_attention_3d(
         # acc : (BLOCK_M, HEAD_SIZE_PADDED)
         acc += tl.dot(P.to(V.dtype), V)
 
-    segm_output_offset = (
-        query_offset_0[:, None].to(tl.int64)
-        * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-        + query_offset_1[:, None] * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-        + segm_idx * HEAD_SIZE_PADDED
-        + tl.arange(0, HEAD_SIZE_PADDED)[None, :]
-    )
-    tl.store(
-        segm_output_ptr + segm_output_offset,
-        acc,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
-    )
+    if USE_TD:
+        acc = acc.to(segm_output_ptr.dtype.element_ty)
+        segm_output_base = (
+            segm_output_ptr
+            + (cur_batch_in_all_start_index
+               + q_block_local_idx * BLOCK_Q).to(tl.int64)
+            * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+            + (kv_head_idx * num_queries_per_kv)
+            * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+            + segm_idx * HEAD_SIZE_PADDED
+        )
+        segm_output_desc = tl.make_tensor_descriptor(
+            base=segm_output_base,
+            shape=(q_block_local_len, num_queries_per_kv, HEAD_SIZE),
+            strides=(
+                num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
+                NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED,
+                1,
+            ),
+            block_shape=(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        )
+        segm_output_desc.store(
+            [0, 0, 0],
+            acc.reshape(BLOCK_Q, num_queries_per_kv, HEAD_SIZE_PADDED),
+        )
+    else:
+        segm_output_offset = (
+            query_offset_0[:, None].to(tl.int64)
+            * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+            + query_offset_1[:, None] * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+            + segm_idx * HEAD_SIZE_PADDED
+            + tl.arange(0, HEAD_SIZE_PADDED)[None, :]
+        )
+        tl.store(
+            segm_output_ptr + segm_output_offset,
+            acc,
+            mask=dim_mask[None, :] & query_mask_0[:, None]
+                 & query_mask_1[:, None],
+        )
     segm_offset = (
         query_offset_0.to(tl.int64) * (num_query_heads * NUM_SEGMENTS_PER_SEQ)
         + query_offset_1 * NUM_SEGMENTS_PER_SEQ
@@ -911,6 +1164,11 @@ def unified_attention(
     # Optional tensor for prefix lengths (PrefixLM support)
     mm_prefix_range=None,
     use_alibi_sqrt=False,
+    # Tensor descriptor mode: use tl.make_tensor_descriptor for Q/K/V/output.
+    # Enables HW 2D block reads on Intel Xe2/Xe3 and TMA on NVIDIA Hopper.
+    # The dead branch is eliminated at Triton compile time, so there is zero
+    # overhead when disabled.
+    use_td: bool = False,
 ):
     assert causal, "Only causal attention is supported"
     assert q_descale is None, "Q scales not supported"
@@ -1040,6 +1298,7 @@ def unified_attention(
             num_seqs=num_seqs,
             BLOCK_M=BLOCK_M,
             USE_FP8=output_scale is not None,
+            USE_TD=use_td,
         )
     else:
         kernel_unified_attention_3d[
@@ -1092,6 +1351,7 @@ def unified_attention(
             num_seqs=num_seqs,
             BLOCK_M=BLOCK_M,
             NUM_SEGMENTS_PER_SEQ=num_par_softmax_segments,
+            USE_TD=use_td,
         )
         reduce_segments[(q.shape[0], num_query_heads)](
             output_ptr=out,


### PR DESCRIPTION
Add a compile-time USE_TD: tl.constexpr flag to kernel_unified_attention_2d and kernel_unified_attention_3d that switches between the original pointer-arithmetic path (USE_TD=False) and a tensor-descriptor path (USE_TD=True) using tl.make_tensor_descriptor.

When USE_TD=True:
- Q is loaded via 2D/3D tensor descriptor instead of masked gather
- K/V cache tiles are loaded via 2D descriptors with .T for K
- Output/segment-output is stored via 3D tensor descriptor

The dead branch is eliminated at Triton compile time, so there is zero overhead on platforms where USE_TD=False. On Intel Xe2/Xe3, tensor descriptors enable HW 2D block reads for significantly better performance.

Auto-detection: TritonAttentionImpl sets use_td=True when running on XPU (current_platform.is_xpu()).

This follows the approach proposed by Whitney Tsang to avoid B200 regression — instead of emitting TMA instructions unconditionally (which causes ~2x overhead on Blackwell DRAM-bound cases), the TD path is only compiled in when explicitly requested.

Replaces the separate-backend approach from PR #35401 with a single kernel, two compile-time paths.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
