### PR TITLE
[XPU][MoE] Add VLLM_TRITON_USE_TD path to batched MoE Triton kernel

### DIFF
--- a/tests/kernels/moe/test_batched_moe.py
+++ b/tests/kernels/moe/test_batched_moe.py
@@ -105,6 +105,7 @@ class BatchedMMTensors:
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("block_shape", [None, [128, 128]])
 @pytest.mark.parametrize("per_act_token_quant", [False, True])
+@pytest.mark.parametrize("use_td", [False, True])
 def test_batched_mm(
     num_experts: int,
     max_tokens_per_expert: int,
@@ -113,9 +114,14 @@ def test_batched_mm(
     dtype: torch.dtype,
     block_shape: list[int] | None,
     per_act_token_quant: bool,
+    use_td: bool,
+    monkeypatch,
 ):
     """Note: float8_e4m3fn is not supported on CUDA architecture < 89,
     and those tests will be skipped on unsupported hardware."""
+    if use_td and not hasattr(tl, "make_tensor_descriptor"):
+        pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
+    monkeypatch.setenv("VLLM_TRITON_USE_TD", "1" if use_td else "0")
     set_random_seed(7)
 
     use_fp8_w8a8 = dtype == torch.float8_e4m3fn
@@ -239,6 +245,7 @@ def test_batched_mm(
 @pytest.mark.parametrize("per_act_token_quant", [False, True])
 @pytest.mark.parametrize("block_shape", [None, [128, 128]])
 @pytest.mark.parametrize("input_scales", [False])
+@pytest.mark.parametrize("use_td", [False, True])
 def test_fused_moe_batched_experts(
     m: int,
     n: int,
@@ -249,10 +256,15 @@ def test_fused_moe_batched_experts(
     per_act_token_quant: bool,
     block_shape: list[int] | None,
     input_scales: bool,
+    use_td: bool,
+    monkeypatch,
     workspace_init,
 ):
     """Note: float8_e4m3fn is not supported on CUDA architecture < 89,
     and those tests will be skipped on unsupported hardware."""
+    if use_td and not hasattr(tl, "make_tensor_descriptor"):
+        pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
+    monkeypatch.setenv("VLLM_TRITON_USE_TD", "1" if use_td else "0")
     set_random_seed(7)
 
     use_fp8_w8a8 = dtype == torch.float8_e4m3fn

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -53,6 +53,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils_test import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import quantize_weights
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
+from vllm.triton_utils import tl
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
 
@@ -289,6 +290,7 @@ def run_moe_test(
 @pytest.mark.parametrize("ep_size", EP_SIZE)
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("padding", [True, False])
+@pytest.mark.parametrize("use_td", [False, True])
 def test_fused_moe(
     m: int,
     n: int,
@@ -298,9 +300,13 @@ def test_fused_moe(
     ep_size: int,
     dtype: torch.dtype,
     padding: bool,
+    use_td: bool,
     monkeypatch,
     workspace_init,
 ):
+    if use_td and not hasattr(tl, "make_tensor_descriptor"):
+        pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
+    monkeypatch.setenv("VLLM_TRITON_USE_TD", "1" if use_td else "0")
     set_random_seed(7)
 
     #

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
     VLLM_BATCH_INVARIANT: bool = False
     VLLM_TRITON_ATTN_USE_TD: bool | None = None
+    VLLM_TRITON_USE_TD: bool | None = None
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
     VLLM_USE_PRECOMPILED: bool = False
@@ -582,6 +583,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # ``0`` forces TD off.  Useful for A/B benchmarking the TD path.
     "VLLM_TRITON_ATTN_USE_TD": lambda: {"1": True, "0": False}.get(
         os.getenv("VLLM_TRITON_ATTN_USE_TD", "").strip()
+    ),
+    # Use tensor descriptors for the A gather and B load in the Triton
+    # fused-MoE kernel.  Tri-state: unset auto-selects per platform
+    # (default-on for XPU); ``1`` / ``0`` force.  Only takes effect when
+    # the active MoE backend is the fused Triton kernel and the weights
+    # are not quantized; otherwise ignored with a one-shot log.
+    "VLLM_TRITON_USE_TD": lambda: {"1": True, "0": False}.get(
+        os.getenv("VLLM_TRITON_USE_TD", "").strip()
     ),
     # Maximum number of compilation jobs to run in parallel.
     # By default this is the number of CPUs

--- a/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py
@@ -19,7 +19,9 @@ from vllm.model_executor.layers.fused_moe.utils import (
     _resize_cache,
     moe_kernel_quantize_input,
     normalize_batched_scales_shape,
+    resolve_moe_use_td,
     swiglu_limit_func,
+    warn_if_moe_use_td_ineffective,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -71,6 +73,13 @@ def moe_mmk(
     use_w8a8: tl.constexpr,
     use_w8a16: tl.constexpr,
     per_act_token_quant: tl.constexpr,
+    # Tensor-descriptor path for the A/B loads in the K-loop.  When
+    # ``USE_TD`` is set the caller passes pre-built descriptors whose base
+    # is already offset to this expert's tile, so the block index is 0 and
+    # only K advances.
+    a_desc=None,
+    b_desc=None,
+    USE_TD: tl.constexpr = False,
 ):
     offs_k = tl.arange(0, BLOCK_K)
 
@@ -108,14 +117,21 @@ def moe_mmk(
     # `accumulator` will be converted back to fp16 after the loop.
     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
-        # Load the next block of A and B, generate a mask by checking the
-        # K dimension.
-        a = tl.load(
-            a_ptrs,
-            mask=mask_m[:, None] & (offs_k[None, :] < K - k * BLOCK_K),
-            other=0.0,
-        )
-        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
+        if USE_TD:
+            # Tokens are already grouped per expert and the descriptor base
+            # is offset to this tile, so the M/N block index is 0 and the
+            # hardware zero-fills past the descriptor shape (no K-tail mask).
+            a = a_desc.load([0, k * BLOCK_K])
+            b = b_desc.load([0, k * BLOCK_K]).T
+        else:
+            # Load the next block of A and B, generate a mask by checking the
+            # K dimension.
+            a = tl.load(
+                a_ptrs,
+                mask=mask_m[:, None] & (offs_k[None, :] < K - k * BLOCK_K),
+                other=0.0,
+            )
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
         # We accumulate along the K dimension.
         if use_w8a16:
             accumulator = tl.dot(a, b.to(compute_type), acc=accumulator)
@@ -135,9 +151,10 @@ def moe_mmk(
         else:
             accumulator += tl.dot(a, b)
 
-        # Advance the ptrs to the next K block.
-        a_ptrs += BLOCK_K * stride_ak
-        b_ptrs += BLOCK_K * stride_bk
+        if not USE_TD:
+            # Advance the ptrs to the next K block.
+            a_ptrs += BLOCK_K * stride_ak
+            b_ptrs += BLOCK_K * stride_bk
 
     if use_w8a16:
         accumulator = (accumulator * b_scale).to(compute_type)
@@ -168,12 +185,18 @@ def expert_triton_kernel(
     b_scale_ptr,
     b_zp_ptr,
     # strides
+    #
+    # The contiguous (last) strides ``stride_ak``/``stride_bk``/``stride_cn``
+    # are left un-annotated on purpose: ``tl.make_tensor_descriptor`` requires
+    # the descriptor's last-dim stride to be a compile-time ``1``, which only
+    # happens via Triton's equal-to-1 specialization for plain (non-int64)
+    # args.  The non-contiguous strides keep ``tl.int64`` to avoid overflow.
     stride_am: tl.int64,
-    stride_ak: tl.int64,
-    stride_bk: tl.int64,
+    stride_ak,
+    stride_bk,
     stride_bn: tl.int64,
     stride_cm: tl.int64,
-    stride_cn: tl.int64,
+    stride_cn,
     stride_ase: tl.int64,
     stride_asm: tl.int64,
     stride_ask: tl.int64,
@@ -193,15 +216,36 @@ def expert_triton_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    # Tensor-descriptor path (non-quantized only); base ptrs are already
+    # offset to this expert's tile.
+    USE_TD: tl.constexpr = False,
 ):
     offs_m = tl.arange(0, BLOCK_M)
     offs_n = tl.arange(0, BLOCK_N) % N
     offs_k = tl.arange(0, BLOCK_K)
     mask_m = offs_m < M
 
-    # Make grids of a + b pointers
-    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
-    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    if USE_TD:
+        a_desc = tl.make_tensor_descriptor(
+            base=a_ptr,
+            shape=(M, K),
+            strides=(stride_am, stride_ak),
+            block_shape=(BLOCK_M, BLOCK_K),
+        )
+        b_desc = tl.make_tensor_descriptor(
+            base=b_ptr,
+            shape=(N, K),
+            strides=(stride_bn, stride_bk),
+            block_shape=(BLOCK_N, BLOCK_K),
+        )
+        a_ptrs = None
+        b_ptrs = None
+    else:
+        # Make grids of a + b pointers
+        a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+        b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+        a_desc = None
+        b_desc = None
 
     accumulator = moe_mmk(
         a_ptrs,
@@ -238,13 +282,27 @@ def expert_triton_kernel(
         use_fp8_w8a8,
         use_int8_w8a16,
         per_act_token_quant,
+        a_desc,
+        b_desc,
+        USE_TD,
     )
 
     # store in C
-    offs_cn = tl.arange(0, BLOCK_N)
-    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_cn[None, :] * stride_cn
-    c_mask = mask_m[:, None] & (offs_cn[None, :] < N)
-    tl.store(c_ptrs, accumulator, mask=c_mask)
+    if USE_TD:
+        # ``shape=(M, N)`` clips the ragged tail in hardware, so no mask is
+        # needed; the base is already offset to this tile so the index is 0.
+        c_desc = tl.make_tensor_descriptor(
+            base=c_ptr,
+            shape=(M, N),
+            strides=(stride_cm, stride_cn),
+            block_shape=(BLOCK_M, BLOCK_N),
+        )
+        c_desc.store([0, 0], accumulator)
+    else:
+        offs_cn = tl.arange(0, BLOCK_N)
+        c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_cn[None, :] * stride_cn
+        c_mask = mask_m[:, None] & (offs_cn[None, :] < N)
+        tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
 @triton.jit
@@ -266,15 +324,20 @@ def batched_triton_kernel(
     # moving by 1 element in a particular dimension. E.g. `stride_am` is
     # how much to increase `a_ptr` by to get the element one row down
     # (A has M rows).
+    #
+    # The contiguous (last) strides ``stride_ak``/``stride_bk``/``stride_cn``
+    # are left un-annotated so Triton's equal-to-1 specialization makes them
+    # compile-time ``1`` — required by ``tl.make_tensor_descriptor`` in the
+    # TD path (and harmless to the pointer path).
     stride_ae: tl.int64,
     stride_am: tl.int64,
-    stride_ak: tl.int64,
+    stride_ak,
     stride_be: tl.int64,
-    stride_bk: tl.int64,
+    stride_bk,
     stride_bn: tl.int64,
     stride_ce: tl.int64,
     stride_cm: tl.int64,
-    stride_cn: tl.int64,
+    stride_cn,
     stride_ase: tl.int64,
     stride_asm: tl.int64,
     stride_ask: tl.int64,
@@ -292,6 +355,8 @@ def batched_triton_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    # Tensor-descriptor path (non-quantized only).
+    USE_TD: tl.constexpr = False,
 ):
     expert_id = tl.program_id(axis=0)
     e_num_tokens = tl.load(expert_num_tokens + expert_id)
@@ -372,6 +437,7 @@ def batched_triton_kernel(
         BLOCK_M,
         BLOCK_N,
         BLOCK_K,
+        USE_TD,
     )
 
 
@@ -397,6 +463,13 @@ def invoke_moe_batched_triton_kernel(
     max_num_tokens = A.size(1)
     K = A.size(2)
     N = C.size(2)
+
+    is_quantized = (
+        use_fp8_w8a8 or use_int8_w8a16 or use_int4_w4a16 or per_act_token_quant
+    )
+    warn_if_moe_use_td_ineffective("BATCHED_TRITON", is_quantized=is_quantized)
+    # TD path is restricted to non-quantized weights; fall back otherwise.
+    use_td = resolve_moe_use_td() and not is_quantized
 
     BLOCK_M = config["BLOCK_SIZE_M"]
     BLOCK_N = config["BLOCK_SIZE_N"]
@@ -485,6 +558,7 @@ def invoke_moe_batched_triton_kernel(
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
         BLOCK_K=BLOCK_K,
+        USE_TD=use_td,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -27,6 +27,8 @@ from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
 )
 from vllm.model_executor.layers.fused_moe.utils import (
     moe_kernel_quantize_input,
+    resolve_moe_use_td,
+    warn_if_moe_use_td_ineffective,
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
@@ -343,6 +345,8 @@ def fused_moe_kernel(
     use_int8_w8a16: tl.constexpr,
     per_channel_quant: tl.constexpr,
     HAS_BIAS: tl.constexpr,
+    # Tensor-descriptor path for the A gather and B load in the K-loop.
+    USE_TD: tl.constexpr = False,
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -432,15 +436,32 @@ def fused_moe_kernel(
 
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (
-        offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
-    )
+    if USE_TD:
+        # ``tt.descriptor_gather`` requires block_shape[0] == 1 and i32 idx.
+        m_td = num_valid_tokens // top_k
+        a_desc = tl.make_tensor_descriptor(
+            base=a_ptr,
+            shape=(m_td, K),
+            strides=(stride_am, stride_ak),
+            block_shape=(1, BLOCK_SIZE_K),
+        )
+        b_desc = tl.make_tensor_descriptor(
+            base=b_ptr + off_experts * stride_be,
+            shape=(N, K),
+            strides=(stride_bn, stride_bk),
+            block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_K),
+        )
+        gather_idx = (offs_token // top_k).to(tl.int32)
+    else:
+        a_ptrs = a_ptr + (
+            offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
+        )
 
-    b_ptrs = (
-        b_ptr
-        + off_experts * stride_be
-        + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
-    )
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+        )
     if use_int8_w8a16:
         b_scale_ptrs = (
             b_scale_ptr + off_experts * stride_bse + offs_bn[None, :] * stride_bsn
@@ -481,12 +502,16 @@ def fused_moe_kernel(
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         # Load the next block of A and B, generate a mask by checking the
         # K dimension.
-        a = tl.load(
-            a_ptrs,
-            mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
-            other=0.0,
-        )
-        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        if USE_TD:
+            a = a_desc.gather(gather_idx, k * BLOCK_SIZE_K)
+            b = b_desc.load([pid_n * BLOCK_SIZE_N, k * BLOCK_SIZE_K]).T
+        else:
+            a = tl.load(
+                a_ptrs,
+                mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+                other=0.0,
+            )
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
         # We accumulate along the K dimension.
         if use_int8_w8a16:
             accumulator = tl.dot(a, b.to(compute_type), acc=accumulator)
@@ -508,9 +533,10 @@ def fused_moe_kernel(
                     accumulator += tl.dot(a, b)
         else:
             accumulator += tl.dot(a, b)
-        # Advance the ptrs to the next K block.
-        a_ptrs += BLOCK_SIZE_K * stride_ak
-        b_ptrs += BLOCK_SIZE_K * stride_bk
+        if not USE_TD:
+            # Advance the ptrs to the next K block.
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+            b_ptrs += BLOCK_SIZE_K * stride_bk
 
     # Dequantization for supported quantization schemes:
     #   - int8_w8a16
@@ -729,6 +755,13 @@ def invoke_fused_moe_triton_kernel(
     assert topk_weights is None or topk_weights.stride(1) == 1
     assert sorted_token_ids is None or sorted_token_ids.stride(0) == 1
 
+    warn_if_moe_use_td_ineffective(
+        "TRITON",
+        is_quantized=(
+            use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16
+        ),
+    )
+
     if use_fp8_w8a8 or use_int8_w8a8:
         assert B_scale is not None
         assert block_shape is None or triton.cdiv(
@@ -810,6 +843,7 @@ def invoke_fused_moe_triton_kernel(
         naive_block_assignment=(sorted_token_ids is None),
         HAS_BIAS=HAS_BIAS,
         BLOCK_SIZE_K=BLOCK_SIZE_K,
+        USE_TD=resolve_moe_use_td(),
         **config,
     )
 

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -89,6 +89,12 @@ def _get_priority_backends(moe_config: FusedMoEConfig) -> list[UnquantizedMoeBac
 def backend_to_kernel_cls(
     backend: UnquantizedMoeBackend,
 ) -> type[mk.FusedMoEExperts]:
+    from vllm.model_executor.layers.fused_moe.utils import (
+        warn_if_moe_use_td_ineffective,
+    )
+
+    warn_if_moe_use_td_ineffective(backend.value, is_quantized=False)
+
     if backend == UnquantizedMoeBackend.FLASHINFER_TRTLLM:
         from vllm.model_executor.layers.fused_moe.experts.trtllm_bf16_moe import (
             TrtLlmBf16Experts,

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
 )
@@ -32,6 +33,8 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
+
+logger = init_logger(__name__)
 
 
 @triton.jit
@@ -462,25 +465,22 @@ def warn_if_moe_use_td_ineffective(
     """One-shot warning when ``VLLM_TRITON_USE_TD`` is set but ignored.
 
     Fires when the user set the env explicitly and either (a) the active
-    MoE backend is not Triton-family, or (b) the model is quantized (the
-    TD path falls back to the pointer path under any quantization).
+    MoE backend is not the fused Triton kernel, or (b) the model is
+    quantized (the TD path falls back to the pointer path under any
+    quantization).
     """
     global _warned_moe_use_td_ineffective
     if _warned_moe_use_td_ineffective:
         return
     if envs.VLLM_TRITON_USE_TD is None:
         return
-    is_triton = "TRITON" in active_backend.upper()
+    is_triton = active_backend.upper() == "TRITON"
     if is_triton and not is_quantized:
         return
-    import logging
-
-    logger = logging.getLogger("vllm")
     if not is_triton:
         reason = (
             f"the active MoE backend is {active_backend!r}; pass "
-            "`--moe-backend triton` (or `triton_unfused` / `batched_triton`) "
-            "to enable the tensor-descriptor path"
+            "`--moe-backend triton` to enable the tensor-descriptor path"
         )
     else:
         reason = (

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -5,6 +5,7 @@ from math import prod
 import torch
 import torch.nn.functional as F
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
@@ -442,3 +443,54 @@ def swiglu_limit_func(
         up = torch.clamp(up, min=-swiglu_limit, max=swiglu_limit)
 
     output.copy_(F.silu(gate) * up)
+
+
+def resolve_moe_use_td() -> bool:
+    """Tri-state resolver for ``VLLM_TRITON_USE_TD`` (auto-on for XPU)."""
+    override = envs.VLLM_TRITON_USE_TD
+    if override is None:
+        return current_platform.is_xpu()
+    return override
+
+
+_warned_moe_use_td_ineffective = False
+
+
+def warn_if_moe_use_td_ineffective(
+    active_backend: str, is_quantized: bool = False
+) -> None:
+    """One-shot warning when ``VLLM_TRITON_USE_TD`` is set but ignored.
+
+    Fires when the user set the env explicitly and either (a) the active
+    MoE backend is not Triton-family, or (b) the model is quantized (the
+    TD path falls back to the pointer path under any quantization).
+    """
+    global _warned_moe_use_td_ineffective
+    if _warned_moe_use_td_ineffective:
+        return
+    if envs.VLLM_TRITON_USE_TD is None:
+        return
+    is_triton = "TRITON" in active_backend.upper()
+    if is_triton and not is_quantized:
+        return
+    import logging
+
+    logger = logging.getLogger("vllm")
+    if not is_triton:
+        reason = (
+            f"the active MoE backend is {active_backend!r}; pass "
+            "`--moe-backend triton` (or `triton_unfused` / `batched_triton`) "
+            "to enable the tensor-descriptor path"
+        )
+    else:
+        reason = (
+            "the model uses quantized MoE weights; the TD path is "
+            "currently restricted to non-quantized weights and falls "
+            "back to the pointer path"
+        )
+    logger.warning(
+        "VLLM_TRITON_USE_TD is set to %s but %s.",
+        envs.VLLM_TRITON_USE_TD,
+        reason,
+    )
+    _warned_moe_use_td_ineffective = True

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -465,22 +465,23 @@ def warn_if_moe_use_td_ineffective(
     """One-shot warning when ``VLLM_TRITON_USE_TD`` is set but ignored.
 
     Fires when the user set the env explicitly and either (a) the active
-    MoE backend is not the fused Triton kernel, or (b) the model is
-    quantized (the TD path falls back to the pointer path under any
-    quantization).
+    MoE backend is not a Triton kernel (fused or batched), or (b) the
+    model is quantized (the TD path falls back to the pointer path under
+    any quantization).
     """
     global _warned_moe_use_td_ineffective
     if _warned_moe_use_td_ineffective:
         return
     if envs.VLLM_TRITON_USE_TD is None:
         return
-    is_triton = active_backend.upper() == "TRITON"
+    is_triton = "TRITON" in active_backend.upper()
     if is_triton and not is_quantized:
         return
     if not is_triton:
         reason = (
             f"the active MoE backend is {active_backend!r}; pass "
-            "`--moe-backend triton` to enable the tensor-descriptor path"
+            "`--moe-backend triton` (or `batched_triton`) to enable the "
+            "tensor-descriptor path"
         )
     else:
         reason = (


### PR DESCRIPTION
## Summary

Add an opt-in tensor-descriptor (TD) path to the **batched** MoE Triton kernels
(`moe_mmk`, `expert_triton_kernel`, `batched_triton_kernel` in
`fused_moe/experts/fused_batched_moe.py`), mirroring the TD path already added to
the standard fused MoE kernel in this branch.

When `VLLM_TRITON_USE_TD` resolves on (tri-state env, auto-on for XPU) **and** the
weights are not quantized, the K-loop loads A/B via `tl.make_tensor_descriptor`
and stores C via a descriptor. Otherwise the existing masked pointer path runs
unchanged — `USE_TD` is a `tl.constexpr` defaulting to `False`, so the baseline is
byte-identical and Triton DCE drops the unused branch.

This is the batched counterpart to the fused-kernel TD work; the env var,
`resolve_moe_use_td()` resolver, and `warn_if_moe_use_td_ineffective()` helper are
shared between both paths.

### Commits

1. `envs: add VLLM_TRITON_USE_TD tri-state env var`
2. `fused_moe: add resolve_moe_use_td() + ineffective-config warning`
3. `fused_moe: add VLLM_TRITON_USE_TD path to fused_moe_kernel`
4. `fused_moe: recognize batched_triton as a TD-capable backend`
5. `fused_moe: add VLLM_TRITON_USE_TD path to batched MoE kernel`

Commits 1–3 are the standard-kernel TD path (also under separate review); 4–5 add
the batched path. They are bundled here because the batched path depends on the
shared env/resolver/warning introduced in 1–3.

## Design notes

- **Descriptor locus.** Descriptors are built in `expert_triton_kernel`, where the
  base pointers are already offset to the per-expert tile and the per-expert
  ragged row count `M` is in scope. The block index is therefore `[0, …]` and the
  hardware clips the ragged tail via the descriptor `shape`, so no explicit
  `mask_m`/K-tail mask is needed in the TD branch.
- **Plain contiguous strides.** `tl.make_tensor_descriptor` requires the
  descriptor's last-dim stride to be a compile-time `1`. That only happens via
  Triton's equal-to-1 specialization for plain (non-`tl.int64`) args, so the
  contiguous strides `stride_ak`/`stride_bk`/`stride_cn` are left un-annotated;
  the non-contiguous strides keep `tl.int64` for overflow safety. The standard
  fused kernel already follows this convention.
- **Quantization gating.** The TD path is restricted to non-quantized weights
  (`use_td = resolve_moe_use_td() and not is_quantized`), computed host-side in
  `invoke_moe_batched_triton_kernel` and passed as a constexpr. Under any
  quantization (fp8 / int8 / int4 / per-act-token) the kernel falls back to the
  pointer path, and `warn_if_moe_use_td_ineffective("BATCHED_TRITON", …)` emits a
  one-shot log if the env was set explicitly.
- **No autotune / no grid-axis change / no constexpr-stride rewrite.** This keeps
  the launch semantics and JIT cache behavior identical to the existing kernel; it
  is a capability change, not a retune.

## Not a duplicate

- The standard-kernel TD path is under separate review; this PR is the **batched**
  follow-up that was intentionally split out. The two share only the env/resolver
  plumbing.
- No open PR adds a tensor-descriptor path to the batched MoE Triton kernel
  (checked `fused_batched_moe`, `make_tensor_descriptor`, `VLLM_TRITON_USE_TD`).

## Testing

Validated on an Intel Battlemage B70 (BMG) GPU, in the XPU container, with the
branch overlaid and the running code verified via `inspect` to be the patched
version.

- `tests/kernels/moe/test_batched_moe.py::test_batched_mm` — the direct
  kernel-launcher test, parametrized over `use_td ∈ {False, True}`:
  - bf16 non-quantized, full N/K/max-tokens/num-experts grid (incl. ragged
    shapes): **48/48 pass** for both `use_td` values.
  - Full 384-case run: **48 passed, 336 skipped** (fp8/block/per-act-token cases
    skip on this arch per the existing test logic), **0 failures**.
- `use_td=False` baseline numerics are unchanged (byte-identical pointer path).
- The `make_tensor_descriptor` contiguous-stride requirement — the only
  platform-specific element — was additionally confirmed on an NVIDIA B200
  (Triton 3.6.0, torch 2.11): a `tl.int64`-annotated contiguous stride fails to
  compile while a plain stride succeeds, identical to XPU. A full CUDA
  `test_batched_mm` run on a current image is a follow-up.

Note: `test_fused_moe_batched_experts` (the higher-level modular-kernel test) is
not yet runnable on XPU — it fails identically for `use_td=False` and `True` due
to pre-existing XPU test-harness gaps (the `workspace_init` fixture initializes
only under CUDA, and the path reaches the CUDA-only
`_cuda_isCurrentStreamCapturing`). This is unrelated to this change; the direct
launcher test fully exercises the kernel.

## AI assistance

This change was developed with AI assistance (Claude). The author reviewed every
changed line, ran the tests above, and is accountable for the change end-to-end.
