### PR TITLE
[Kernel] TD scatter path for MoE write_zeros_to_output

### DIFF
--- a/benchmarks/kernels/benchmark_moe_write_zeros_td.py
+++ b/benchmarks/kernels/benchmark_moe_write_zeros_td.py
@@ -34,22 +34,24 @@ from vllm.utils.torch_utils import set_random_seed
 DEVICE = current_platform.device_type  # "cuda" (also reported by ROCm) or "xpu"
 
 # (m, n, k): first row matches test_fused_moe_all_experts_pruned exactly. The
-# rest are real model (m, n) pairs -- m = small decode-like vs large EP-batch
-# token count, n = B.size(1) in fused_moe_kernel (either the gate_up
-# projection width 2 * intermediate_size, or the down projection width
-# hidden_size), per benchmark_moe.py's get_model_params() convention:
+# rest are real model (m, n, k) triples -- m = small decode-like vs large
+# EP-batch token count; n = B.size(1) in fused_moe_kernel, the GEMM output
+# width (gate_up projection: 2 * intermediate_size, or down projection:
+# hidden_size); k = B.size(2), the corresponding GEMM reduction width
+# (hidden_size for gate_up, intermediate_size for down) -- per
+# benchmark_moe.py's get_model_params() convention:
 #   - Mixtral-8x7B: hidden=4096, intermediate=14336
 #   - DeepSeek-V3:  hidden=7168, moe_intermediate=2048
 # k has no effect on this kernel's cost (no arithmetic, pure zero store) --
-# kept only as some value for label/config-lookup parity with the unit
-# test, using n's model's hidden_size. E/TOPK below are likewise fixed
-# (Mixtral-style) across all rows -- only get_default_config's tuning
-# heuristics consume them, not the benchmarked store itself.
+# kept accurate to the real GEMM shape only for config-lookup parity with
+# get_default_config. E/TOPK below are likewise fixed (Mixtral-style) across
+# all rows -- only get_default_config's tuning heuristics consume them, not
+# the benchmarked store itself.
 PROBLEM_SIZES = [
     (83, 512, 256),
-    (32, 4096, 4096),  # Mixtral-8x7B down-proj, small decode-like batch
+    (32, 4096, 14336),  # Mixtral-8x7B down-proj, small decode-like batch
     (2048, 28672, 4096),  # Mixtral-8x7B gate_up-proj, EP-realistic batch
-    (8192, 2048, 7168),  # DeepSeek-V3 gate_up-proj, large EP batch
+    (8192, 4096, 7168),  # DeepSeek-V3 gate_up-proj, large EP batch
 ]
 E, TOPK = 8, 2  # only feeds get_default_config's tuning heuristics
 

--- a/benchmarks/kernels/benchmark_moe_write_zeros_td.py
+++ b/benchmarks/kernels/benchmark_moe_write_zeros_td.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Microbenchmark: TD-scatter vs pointer-store for write_zeros_to_output
+(the fused-MoE zero-fill store for EP-pruned expert blocks).
+
+Isolates write_zeros_to_output via a thin @triton.jit launcher (no GEMM, no
+fused_moe() overhead) with a synthetic sorted_token_ids array padded the
+same way moe_align_block_size() pads it: padding sentinel = num_valid_tokens,
+dropped by token_mask (pointer path) / the descriptor row bound (TD path).
+
+Run inside the vLLM container:
+    python3 benchmarks/kernels/benchmark_moe_write_zeros_td.py [--repeats 3]
+"""
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    get_default_config,
+    write_zeros_to_output,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.utils.torch_utils import set_random_seed
+
+DEVICE = current_platform.device_type  # "cuda" or "xpu"
+
+# (m, n, k): first two match test_fused_moe_all_experts_pruned exactly; the
+# larger two are illustrative EP-batch sizes, not derived from a specific
+# model. k has no effect on this kernel's cost (no arithmetic, pure zero
+# store) -- kept only for label parity with the unit test / config lookup.
+PROBLEM_SIZES = [
+    (83, 512, 256),
+    (1, 1024, 512),
+    (2048, 4096, 4096),
+    (8192, 4096, 4096),
+]
+E, TOPK = 8, 2  # only feeds get_default_config's tuning heuristics
+
+
+@triton.jit
+def _write_zeros_launcher(
+    c_ptr,
+    stride_cm,
+    stride_cn,
+    N,
+    sorted_token_ids_ptr,
+    num_valid_tokens,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    USE_TD: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id).to(tl.int64)
+    token_mask = offs_token < num_valid_tokens
+    write_zeros_to_output(
+        c_ptr,
+        stride_cm,
+        stride_cn,
+        pid_n,
+        N,
+        offs_token,
+        token_mask,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        tl.bfloat16,
+        num_valid_tokens,
+        USE_TD=USE_TD,
+    )
+
+
+def _make_inputs(m, n, block_m, device):
+    em = triton.cdiv(m, block_m) * block_m  # padded, like moe_align_block_size
+    sorted_token_ids = torch.arange(em, device=device, dtype=torch.int64)
+    sorted_token_ids = torch.where(sorted_token_ids < m, sorted_token_ids, m)
+    c = torch.full((m + 1, n), 7.0, device=device, dtype=torch.bfloat16)
+    return c, sorted_token_ids, em
+
+
+def bench_one(m, n, k, use_td):
+    set_random_seed(42)
+    config = get_default_config(m, E, n, k, TOPK, dtype=None)
+    block_m, block_n = config["BLOCK_SIZE_M"], config["BLOCK_SIZE_N"]
+    c, sorted_token_ids, em = _make_inputs(m, n, block_m, DEVICE)
+    grid = (triton.cdiv(em, block_m), triton.cdiv(n, block_n))
+
+    def run():
+        _write_zeros_launcher[grid](
+            c,
+            c.stride(0),
+            c.stride(1),
+            n,
+            sorted_token_ids,
+            m,
+            BLOCK_SIZE_M=block_m,
+            BLOCK_SIZE_N=block_n,
+            USE_TD=use_td,
+        )
+
+    ms, _, _ = triton.testing.do_bench(run, quantiles=[0.5, 0.2, 0.8])
+    return ms * 1000  # ms -> us
+
+
+def main():
+    parser = FlexibleArgumentParser(
+        description="Benchmark write_zeros_to_output: TD scatter vs pointer store."
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help="process-level repeats; report median-of-medians",
+    )
+    args = parser.parse_args()
+
+    has_td = hasattr(tl, "make_tensor_descriptor")
+    if not has_td:
+        print(
+            "Triton lacks tl.make_tensor_descriptor -- TD path unavailable, "
+            "reporting pointer-path only."
+        )
+
+    print(f"device={DEVICE}")
+    print(f"{'m':>6} {'n':>6} {'k':>6} {'pointer_us':>11} {'td_us':>11} {'delta%':>8}")
+    for m, n, k in PROBLEM_SIZES:
+        offs, ons = [], []
+        for _ in range(args.repeats):
+            offs.append(bench_one(m, n, k, use_td=False))
+            if has_td:
+                ons.append(bench_one(m, n, k, use_td=True))
+        off_med = sorted(offs)[len(offs) // 2]
+        if ons:
+            on_med = sorted(ons)[len(ons) // 2]
+            delta = (on_med - off_med) / off_med * 100
+            print(
+                f"{m:>6} {n:>6} {k:>6} {off_med:>11.2f} {on_med:>11.2f} {delta:>+7.2f}%"
+            )
+        else:
+            print(f"{m:>6} {n:>6} {k:>6} {off_med:>11.2f} {'n/a':>11} {'n/a':>8}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_moe_write_zeros_td.py
+++ b/benchmarks/kernels/benchmark_moe_write_zeros_td.py
@@ -3,6 +3,14 @@
 """Microbenchmark: TD-scatter vs pointer-store for write_zeros_to_output
 (the fused-MoE zero-fill store for EP-pruned expert blocks).
 
+Per AGENTS.md, kernel perf work belongs in benchmarks/kernels/, not tests/.
+This script also makes the write_zeros_to_output TD-vs-pointer numbers
+independently reproducible: an earlier review round on this PR flagged that
+the original "TD path is slower at 3 of 4 sizes" claim came from a
+task-local script not checked into the PR, so it couldn't be re-run by a
+reviewer. This is the checked-in replacement, used to justify
+resolve_moe_write_zeros_use_td()'s default-off gating.
+
 Isolates write_zeros_to_output via a thin @triton.jit launcher (no GEMM, no
 fused_moe() overhead) with a synthetic sorted_token_ids array padded the
 same way moe_align_block_size() pads it: padding sentinel = num_valid_tokens,
@@ -23,17 +31,25 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.torch_utils import set_random_seed
 
-DEVICE = current_platform.device_type  # "cuda" or "xpu"
+DEVICE = current_platform.device_type  # "cuda" (also reported by ROCm) or "xpu"
 
-# (m, n, k): first two match test_fused_moe_all_experts_pruned exactly; the
-# larger two are illustrative EP-batch sizes, not derived from a specific
-# model. k has no effect on this kernel's cost (no arithmetic, pure zero
-# store) -- kept only for label parity with the unit test / config lookup.
+# (m, n, k): first row matches test_fused_moe_all_experts_pruned exactly. The
+# rest are real model (m, n) pairs -- m = small decode-like vs large EP-batch
+# token count, n = B.size(1) in fused_moe_kernel (either the gate_up
+# projection width 2 * intermediate_size, or the down projection width
+# hidden_size), per benchmark_moe.py's get_model_params() convention:
+#   - Mixtral-8x7B: hidden=4096, intermediate=14336
+#   - DeepSeek-V3:  hidden=7168, moe_intermediate=2048
+# k has no effect on this kernel's cost (no arithmetic, pure zero store) --
+# kept only as some value for label/config-lookup parity with the unit
+# test, using n's model's hidden_size. E/TOPK below are likewise fixed
+# (Mixtral-style) across all rows -- only get_default_config's tuning
+# heuristics consume them, not the benchmarked store itself.
 PROBLEM_SIZES = [
     (83, 512, 256),
-    (1, 1024, 512),
-    (2048, 4096, 4096),
-    (8192, 4096, 4096),
+    (32, 4096, 4096),  # Mixtral-8x7B down-proj, small decode-like batch
+    (2048, 28672, 4096),  # Mixtral-8x7B gate_up-proj, EP-realistic batch
+    (8192, 2048, 7168),  # DeepSeek-V3 gate_up-proj, large EP batch
 ]
 E, TOPK = 8, 2  # only feeds get_default_config's tuning heuristics
 

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -584,6 +584,11 @@ def test_fused_moe_mixed_ep_td_matches_pointer(
     # Half the experts pruned from the local EP rank, half kept -- every
     # launch mixes real GEMM blocks with write_zeros_to_output blocks.
     local_e = e // 2
+    # Bias one local expert's score so it's always top-k-selected for every
+    # token: with small m, random routing can otherwise select only pruned
+    # experts for every token, making the output legitimately all-zero and
+    # failing the non-zero precondition below without any kernel defect.
+    score[:, local_e - 1] += 100.0
     e_ids = torch.arange(local_e, device=device, dtype=torch.int32)
     e_map = torch.full((e,), -1, device=device, dtype=torch.int32)
     e_map[e_ids] = torch.arange(local_e, device=device, dtype=torch.int32)

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -36,6 +36,10 @@ from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
     batched_fused_marlin_moe,
     fused_marlin_moe,
 )
+from vllm.model_executor.layers.fused_moe.fused_moe import write_zeros_to_output
+from vllm.model_executor.layers.fused_moe.utils import (
+    moe_write_zeros_td_hw_supported,
+)
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_permute_bias,
 )
@@ -53,6 +57,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils_test import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import quantize_weights
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
+from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
 
@@ -394,6 +399,298 @@ def test_fused_moe(
             use_compile=use_compile,
             use_cudagraph=use_cudagraph,
         )
+
+
+_TD_SCATTER_UNSUPPORTED_SKIP_REASON = (
+    "tensor_descriptor.scatter requires XPU or NVIDIA Blackwell "
+    "(sm100 family); lowers to tile::scatter4 (tcgen05/TMEM), which "
+    "ptxas rejects on Hopper (sm90) and earlier"
+)
+
+
+@pytest.mark.parametrize("m,n,k", [(83, 512, 256), (1, 1024, 512)])
+@pytest.mark.parametrize("e", [8])
+@pytest.mark.parametrize("topk", [2])
+@pytest.mark.parametrize("use_td", [False, True])
+def test_fused_moe_all_experts_pruned(
+    m: int,
+    n: int,
+    k: int,
+    e: int,
+    topk: int,
+    use_td: bool,
+    monkeypatch,
+    workspace_init,
+):
+    """All experts off the local EP rank -> every block hits
+    ``write_zeros_to_output``. Output must be exactly zero on both the
+    pointer and the tensor-descriptor (USE_TD) store paths."""
+    if use_td and not hasattr(tl, "make_tensor_descriptor"):
+        pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
+    if use_td and not moe_write_zeros_td_hw_supported():
+        pytest.skip(_TD_SCATTER_UNSUPPORTED_SKIP_REASON)
+    monkeypatch.setenv("VLLM_TRITON_USE_TD", "1" if use_td else "0")
+    set_random_seed(7)
+
+    device = current_platform.device_type
+    a = torch.randn((m, k), device=device, dtype=torch.bfloat16) / 10
+    w1 = torch.randn((e, 2 * n, k), device=device, dtype=torch.bfloat16) / 10
+    w2 = torch.randn((e, k, n), device=device, dtype=torch.bfloat16) / 10
+    score = torch.randn((m, e), device=device, dtype=torch.bfloat16)
+
+    # Empty local rank: expert_map is all -1 so off_experts == -1 for every
+    # block, exercising only the zero-write path.
+    e_map = torch.full((e,), -1, device=device, dtype=torch.int32)
+
+    with set_current_vllm_config(vllm_config):
+        out = fused_moe(
+            a,
+            w1,
+            w2,
+            score,
+            topk,
+            renormalize=False,
+            global_num_experts=e,
+            expert_map=e_map,
+        )
+
+    assert torch.count_nonzero(out) == 0, (
+        f"expected all-zero output for pruned experts, got "
+        f"{torch.count_nonzero(out).item()} non-zero elements (use_td={use_td})"
+    )
+
+
+@triton.jit
+def _write_zeros_to_output_launcher(
+    c_ptr,
+    stride_cm,
+    stride_cn,
+    N,
+    sorted_token_ids_ptr,
+    num_valid_tokens,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    USE_TD: tl.constexpr,
+):
+    """Thin single-block launcher exercising write_zeros_to_output in
+    isolation -- no GEMM, no fused_moe() overhead, no Python-side
+    intermediate_cache pre-zeroing. Mirrors
+    benchmarks/kernels/benchmark_moe_write_zeros_td.py."""
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id).to(tl.int64)
+    token_mask = offs_token < num_valid_tokens
+    write_zeros_to_output(
+        c_ptr,
+        stride_cm,
+        stride_cn,
+        pid_n,
+        N,
+        offs_token,
+        token_mask,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        tl.bfloat16,
+        num_valid_tokens,
+        USE_TD=USE_TD,
+    )
+
+
+@pytest.mark.parametrize("m,n", [(83, 512), (1, 1024), (37, 104)])
+@pytest.mark.parametrize("use_td", [False, True])
+def test_write_zeros_to_output_scatter_targets_correct_rows(
+    m: int,
+    n: int,
+    use_td: bool,
+    workspace_init,
+):
+    """Directly exercises write_zeros_to_output's scatter/store, pre-filled
+    with a non-zero sentinel -- unlike the end-to-end all-pruned tests
+    above, which read back an output that ``fused_experts_impl`` already
+    zeroed in Python (``intermediate_cache3.zero_()`` when ``expert_map is
+    not None``) before the kernel ever runs. That makes an all-zero
+    assertion on ``fused_moe()`` output pass identically whether the
+    scatter is correct, a no-op, or targets the wrong rows. Here the
+    sentinel is written by the test itself, immediately before the launch,
+    so only a correct row-scatter can produce the expected result.
+
+    ``(m, n)`` includes one case, (37, 104), where N is not a multiple of
+    BLOCK_SIZE_N=64 -- 104 is the smallest multiple of 8 bf16 elements (the
+    16-byte tensor-descriptor stride-alignment requirement) above 64 that
+    still isn't itself block-aligned -- to exercise the TD descriptor's
+    column-bound clamp on a tail tile. The pointer path's ``offs_cn < N``
+    mask has no TD equivalent test elsewhere.
+    """
+    if use_td and not hasattr(tl, "make_tensor_descriptor"):
+        pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
+    if use_td and not moe_write_zeros_td_hw_supported():
+        pytest.skip(_TD_SCATTER_UNSUPPORTED_SKIP_REASON)
+
+    device = current_platform.device_type
+    set_random_seed(7)
+
+    block_m, block_n = 16, 64
+    em = triton.cdiv(m, block_m) * block_m  # padded, like moe_align_block_size
+
+    # sorted_token_ids: valid rows [0, m), padding sentinel = m (dropped by
+    # token_mask on the pointer path / the descriptor row bound on TD).
+    sorted_token_ids = torch.arange(em, device=device, dtype=torch.int64)
+    sorted_token_ids = torch.where(sorted_token_ids < m, sorted_token_ids, m)
+
+    SENTINEL = 7.0
+    c = torch.full((m + 1, n), SENTINEL, device=device, dtype=torch.bfloat16)
+    c_before = c.clone()
+
+    grid = (triton.cdiv(em, block_m), triton.cdiv(n, block_n))
+    _write_zeros_to_output_launcher[grid](
+        c,
+        c.stride(0),
+        c.stride(1),
+        n,
+        sorted_token_ids,
+        m,
+        BLOCK_SIZE_M=block_m,
+        BLOCK_SIZE_N=block_n,
+        USE_TD=use_td,
+    )
+
+    # Every valid row [0, m) must be zeroed...
+    assert torch.all(c[:m] == 0.0), (
+        f"expected rows [0:{m}] zeroed by write_zeros_to_output "
+        f"(use_td={use_td}), found non-zero values"
+    )
+    # ...and the guard row (m, the padding sentinel's target, out of the
+    # descriptor's row bound) must be untouched -- a scatter that ignores
+    # the row bound or drops the mask would corrupt it.
+    assert torch.equal(c[m], c_before[m]), (
+        f"padding row {m} was written to (use_td={use_td}); the descriptor "
+        "row bound / token_mask failed to drop the out-of-bounds index"
+    )
+
+
+@pytest.mark.parametrize("m,n,k", [(83, 512, 256), (1, 1024, 512)])
+def test_fused_moe_mixed_ep_td_matches_pointer(
+    m: int,
+    n: int,
+    k: int,
+    monkeypatch,
+    workspace_init,
+):
+    """Mixed EP (some experts pruned, some local) end-to-end sanity check:
+    the TD and pointer store paths must produce bit-identical
+    ``fused_moe()`` output. This is a coarser, whole-pipeline companion to
+    ``test_write_zeros_to_output_scatter_targets_correct_rows`` above (which
+    is the one that can actually fail on a scatter defect, since
+    ``intermediate_cache3`` is pre-zeroed in Python before this test's
+    kernels ever run -- see that test's docstring)."""
+    if not hasattr(tl, "make_tensor_descriptor"):
+        pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
+    if not moe_write_zeros_td_hw_supported():
+        pytest.skip(_TD_SCATTER_UNSUPPORTED_SKIP_REASON)
+
+    e, topk = 8, 2
+    device = current_platform.device_type
+    set_random_seed(7)
+    a = torch.randn((m, k), device=device, dtype=torch.bfloat16) / 10
+    w1 = torch.randn((e, 2 * n, k), device=device, dtype=torch.bfloat16) / 10
+    w2 = torch.randn((e, k, n), device=device, dtype=torch.bfloat16) / 10
+    score = torch.randn((m, e), device=device, dtype=torch.bfloat16)
+
+    # Half the experts pruned from the local EP rank, half kept -- every
+    # launch mixes real GEMM blocks with write_zeros_to_output blocks.
+    local_e = e // 2
+    e_ids = torch.arange(local_e, device=device, dtype=torch.int32)
+    e_map = torch.full((e,), -1, device=device, dtype=torch.int32)
+    e_map[e_ids] = torch.arange(local_e, device=device, dtype=torch.int32)
+    w1_local = w1[e_ids]
+    w2_local = w2[e_ids]
+
+    def run(use_td: bool) -> torch.Tensor:
+        monkeypatch.setenv("VLLM_TRITON_USE_TD", "1" if use_td else "0")
+        with set_current_vllm_config(vllm_config):
+            return fused_moe(
+                a,
+                w1_local,
+                w2_local,
+                score,
+                topk,
+                renormalize=False,
+                global_num_experts=e,
+                expert_map=e_map,
+            )
+
+    out_pointer = run(use_td=False)
+    out_td = run(use_td=True)
+
+    assert torch.count_nonzero(out_pointer) > 0, (
+        "expected some non-zero output from local experts"
+    )
+    torch.testing.assert_close(out_pointer, out_td, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.parametrize("use_td", [False, True])
+def test_fused_moe_all_experts_pruned_int64_overflow(
+    use_td: bool, monkeypatch, workspace_init
+):
+    """Regression test for int32 overflow in the TD scatter descriptor's
+    internal offset math.
+
+    ``test_fused_moe_int64_overflow`` below covers the pointer path's
+    ``offs_token.to(tl.int64)`` cast, but never exercises
+    ``write_zeros_to_output`` (no ``expert_map`` is passed, so
+    ``off_experts`` is never ``-1``). Mirrors that test's M/N so
+    ``row * N`` exceeds int32 max, but also prunes every expert so every
+    block hits the zero-write path with ``scatter_idx`` (cast to
+    ``tl.int32``, since it only needs to address the row count, not the
+    byte offset) landing near the overflow boundary.
+    """
+    if use_td and not hasattr(tl, "make_tensor_descriptor"):
+        pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
+    if use_td and not moe_write_zeros_td_hw_supported():
+        pytest.skip(_TD_SCATTER_UNSUPPORTED_SKIP_REASON)
+    monkeypatch.setenv("VLLM_TRITON_USE_TD", "1" if use_td else "0")
+
+    # ~12 GB GPU memory needed for intermediate caches
+    free_mem = torch.accelerator.get_memory_info()[0]
+    if free_mem < 12 * 1024**3:
+        pytest.skip("Insufficient GPU memory for overflow test")
+
+    set_random_seed(7)
+
+    m, n, k, e, topk = 100000, 2048, 1024, 8, 6
+    device = current_platform.device_type
+    dtype = torch.bfloat16
+
+    a = torch.randn((m, k), device=device, dtype=dtype) / 10
+    w1 = torch.randn((e, 2 * n, k), device=device, dtype=dtype) / 10
+    w2 = torch.randn((e, k, n), device=device, dtype=dtype) / 10
+    score = torch.randn((m, e), device=device, dtype=dtype)
+
+    # C has shape (M, topk, N) where N = w1.size(1) = 2*n; the scattered
+    # zero block's row offset (row * N) must exceed int32 max for this
+    # test to be meaningful.
+    N = w1.size(1)
+    assert N * m * topk > 2**31 - 1, "Test params don't trigger int32 overflow"
+
+    e_map = torch.full((e,), -1, device=device, dtype=torch.int32)
+
+    with set_current_vllm_config(vllm_config):
+        out = fused_moe(
+            a,
+            w1,
+            w2,
+            score,
+            topk,
+            renormalize=False,
+            global_num_experts=e,
+            expert_map=e_map,
+        )
+
+    assert torch.count_nonzero(out) == 0, (
+        f"expected all-zero output for pruned experts, got "
+        f"{torch.count_nonzero(out).item()} non-zero elements (use_td={use_td})"
+    )
 
 
 def test_fused_moe_int64_overflow(workspace_init):

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -472,9 +472,8 @@ def _write_zeros_to_output_launcher(
     BLOCK_SIZE_N: tl.constexpr,
     USE_TD: tl.constexpr,
 ):
-    """Thin single-block launcher exercising write_zeros_to_output in
-    isolation -- no GEMM, no fused_moe() overhead, no Python-side
-    intermediate_cache pre-zeroing. Mirrors
+    """Thin launcher exercising write_zeros_to_output in isolation, no
+    GEMM/fused_moe() overhead. Mirrors
     benchmarks/kernels/benchmark_moe_write_zeros_td.py."""
     pid_m = tl.program_id(axis=0)
     pid_n = tl.program_id(axis=1)
@@ -505,22 +504,10 @@ def test_write_zeros_to_output_scatter_targets_correct_rows(
     use_td: bool,
     workspace_init,
 ):
-    """Directly exercises write_zeros_to_output's scatter/store, pre-filled
-    with a non-zero sentinel -- unlike the end-to-end all-pruned tests
-    above, which read back an output that ``fused_experts_impl`` already
-    zeroed in Python (``intermediate_cache3.zero_()`` when ``expert_map is
-    not None``) before the kernel ever runs. That makes an all-zero
-    assertion on ``fused_moe()`` output pass identically whether the
-    scatter is correct, a no-op, or targets the wrong rows. Here the
-    sentinel is written by the test itself, immediately before the launch,
-    so only a correct row-scatter can produce the expected result.
-
-    ``(m, n)`` includes one case, (37, 104), where N is not a multiple of
-    BLOCK_SIZE_N=64 -- 104 is the smallest multiple of 8 bf16 elements (the
-    16-byte tensor-descriptor stride-alignment requirement) above 64 that
-    still isn't itself block-aligned -- to exercise the TD descriptor's
-    column-bound clamp on a tail tile. The pointer path's ``offs_cn < N``
-    mask has no TD equivalent test elsewhere.
+    """Directly exercises write_zeros_to_output's scatter/store against a
+    pre-filled non-zero sentinel, so a wrong-row or no-op scatter is
+    detectable (unlike asserting zero on `fused_moe()` output -- see PR
+    description). (37, 104) covers N not a multiple of BLOCK_SIZE_N=64.
     """
     if use_td and not hasattr(tl, "make_tensor_descriptor"):
         pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
@@ -577,13 +564,10 @@ def test_fused_moe_mixed_ep_td_matches_pointer(
     monkeypatch,
     workspace_init,
 ):
-    """Mixed EP (some experts pruned, some local) end-to-end sanity check:
-    the TD and pointer store paths must produce bit-identical
-    ``fused_moe()`` output. This is a coarser, whole-pipeline companion to
-    ``test_write_zeros_to_output_scatter_targets_correct_rows`` above (which
-    is the one that can actually fail on a scatter defect, since
-    ``intermediate_cache3`` is pre-zeroed in Python before this test's
-    kernels ever run -- see that test's docstring)."""
+    """Mixed EP (some experts pruned, some local): TD and pointer store
+    paths must produce bit-identical `fused_moe()` output. Coarser
+    whole-pipeline companion to
+    `test_write_zeros_to_output_scatter_targets_correct_rows`."""
     if not hasattr(tl, "make_tensor_descriptor"):
         pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
     if not moe_write_zeros_td_hw_supported():
@@ -634,17 +618,8 @@ def test_fused_moe_all_experts_pruned_int64_overflow(
     use_td: bool, monkeypatch, workspace_init
 ):
     """Regression test for int32 overflow in the TD scatter descriptor's
-    internal offset math.
-
-    ``test_fused_moe_int64_overflow`` below covers the pointer path's
-    ``offs_token.to(tl.int64)`` cast, but never exercises
-    ``write_zeros_to_output`` (no ``expert_map`` is passed, so
-    ``off_experts`` is never ``-1``). Mirrors that test's M/N so
-    ``row * N`` exceeds int32 max, but also prunes every expert so every
-    block hits the zero-write path with ``scatter_idx`` (cast to
-    ``tl.int32``, since it only needs to address the row count, not the
-    byte offset) landing near the overflow boundary.
-    """
+    row-index cast. Mirrors `test_fused_moe_int64_overflow`'s M/N, but also
+    prunes every expert so every block hits write_zeros_to_output."""
     if use_td and not hasattr(tl, "make_tensor_descriptor"):
         pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
     if use_td and not moe_write_zeros_td_hw_supported():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -601,21 +601,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable batch-invariant mode: deterministic results regardless of
     # batch composition. Requires NVIDIA GPU with compute capability >= 9.0.
     "VLLM_BATCH_INVARIANT": lambda: bool(int(os.getenv("VLLM_BATCH_INVARIANT", "0"))),
-    # Use tensor descriptors for TD-eligible Triton kernel paths. Shared
-    # across two independent kernels: (1) Q/K/V loads and output stores in
-    # the Triton unified-attention kernel (enables HW 2D block reads on
-    # Intel XPU; the non-TD branch is dead-code-eliminated at Triton compile
-    # time so other platforms see no overhead), and (2) the tensor-descriptor
-    # scatter in the fused-MoE `write_zeros_to_output` zero-fill store for
-    # EP-pruned expert blocks. Setting this flag affects both paths -- there
-    # is no way to control them independently. Tri-state override: unset
-    # (default) lets each path auto-select per platform (attention: TD on
-    # for XPU only; MoE write_zeros: TD off everywhere -- microbenchmarks
-    # showed it slower than the pointer path at most problem sizes, see
-    # `moe_write_zeros_td_hw_supported`); ``1`` forces TD on for both paths
-    # (raises ``ValueError`` at call time for either path if the current
-    # hardware can't run it); ``0`` forces TD off for both. Useful for A/B
-    # benchmarking.
+    # Enables the tensor-descriptor (TD) path in TD-eligible Triton kernels.
+    # Tri-state: unset (default) auto-selects per platform, currently
+    # auto-on for XPU; ``1``/``0`` force TD on/off regardless of platform.
     "VLLM_TRITON_USE_TD": lambda: {"1": True, "0": False}.get(
         os.getenv("VLLM_TRITON_USE_TD", "").strip()
     ),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -601,13 +601,21 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable batch-invariant mode: deterministic results regardless of
     # batch composition. Requires NVIDIA GPU with compute capability >= 9.0.
     "VLLM_BATCH_INVARIANT": lambda: bool(int(os.getenv("VLLM_BATCH_INVARIANT", "0"))),
-    # Use tensor descriptors for Q/K/V loads and output stores in the
-    # Triton unified-attention kernel.  Enables HW 2D block reads on
-    # Intel XPU; the non-TD branch is dead-code-eliminated at Triton
-    # compile time so other platforms see no overhead.  Tri-state override:
-    # unset (default) lets the `triton_attn` backend auto-select per
-    # platform (currently auto-enabled on XPU only); ``1`` forces TD on;
-    # ``0`` forces TD off.  Useful for A/B benchmarking the TD path.
+    # Use tensor descriptors for TD-eligible Triton kernel paths. Shared
+    # across two independent kernels: (1) Q/K/V loads and output stores in
+    # the Triton unified-attention kernel (enables HW 2D block reads on
+    # Intel XPU; the non-TD branch is dead-code-eliminated at Triton compile
+    # time so other platforms see no overhead), and (2) the tensor-descriptor
+    # scatter in the fused-MoE `write_zeros_to_output` zero-fill store for
+    # EP-pruned expert blocks. Setting this flag affects both paths -- there
+    # is no way to control them independently. Tri-state override: unset
+    # (default) lets each path auto-select per platform (attention: TD on
+    # for XPU only; MoE write_zeros: TD off everywhere -- microbenchmarks
+    # showed it slower than the pointer path at most problem sizes, see
+    # `moe_write_zeros_td_hw_supported`); ``1`` forces TD on for both paths
+    # (raises ``ValueError`` at call time for either path if the current
+    # hardware can't run it); ``0`` forces TD off for both. Useful for A/B
+    # benchmarking.
     "VLLM_TRITON_USE_TD": lambda: {"1": True, "0": False}.get(
         os.getenv("VLLM_TRITON_USE_TD", "").strip()
     ),

--- a/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
@@ -139,6 +139,10 @@ def fused_moe_nvfp4_emulation_kernel(
             BLOCK_SIZE_M,
             BLOCK_SIZE_N,
             compute_type,
+            num_valid_tokens,
+            # TD load/store path is not wired up for the NVFP4 emulation
+            # kernel, so the zero store stays on the pointer path.
+            USE_TD=False,
         )
         return
 

--- a/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
@@ -140,8 +140,6 @@ def fused_moe_nvfp4_emulation_kernel(
             BLOCK_SIZE_N,
             compute_type,
             num_valid_tokens,
-            # TD load/store path is not wired up for the NVFP4 emulation
-            # kernel, so the zero store stays on the pointer path.
             USE_TD=False,
         )
         return

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -28,13 +28,20 @@ from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
 from vllm.model_executor.layers.fused_moe.utils import (
     enable_swap_ab,
     moe_kernel_quantize_input,
+    resolve_moe_write_zeros_use_td,
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.triton_utils.allocation import set_triton_allocator
 from vllm.utils.platform_utils import get_device_name_as_file_name
 from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
+
+
+@functools.lru_cache
+def _set_triton_allocator_once(device: torch.device) -> None:
+    set_triton_allocator(device)
 
 
 @triton.jit
@@ -49,12 +56,42 @@ def write_zeros_to_output(
     BLOCK_SIZE_M,
     BLOCK_SIZE_N,
     compute_type,
+    num_valid_tokens,
+    # Tensor-descriptor store for the scattered zero write. False keeps the
+    # pointer path. When True, num_valid_tokens must fit in int32 (the
+    # scatter row index), enforced by the caller in
+    # invoke_fused_moe_triton_kernel.
+    USE_TD: tl.constexpr = False,
 ):
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=compute_type)
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
-    tl.store(c_ptrs, accumulator, mask=c_mask)
+    if USE_TD:
+        # C is viewed as a flat (num_valid_tokens, N) matrix; the zero block is
+        # scattered to the (non-contiguous) ``offs_token`` rows.
+        # ``tt.descriptor_scatter`` requires block_shape[0] == 1 and i32
+        # indices. Padded slots carry ``offs_token >= num_valid_tokens`` and
+        # are dropped by the descriptor's row-shape bound (the scatter API has
+        # no mask), so no out-of-bounds write occurs.
+        #
+        # Unasserted precondition: tl.make_tensor_descriptor requires the
+        # last dim to be contiguous (stride_cn == 1) and c_ptr to be
+        # 16-byte aligned. Every current caller passes a fresh contiguous
+        # cache with N a multiple of 128, so this holds today, but a
+        # future caller with a strided/unaligned C would silently
+        # miscompile or fail at compile time rather than fall back to the
+        # pointer path (which tolerates arbitrary strides).
+        c_desc = tl.make_tensor_descriptor(
+            base=c_ptr,
+            shape=(num_valid_tokens, N),
+            strides=(stride_cm, stride_cn),
+            block_shape=(1, BLOCK_SIZE_N),
+        )
+        scatter_idx = offs_token.to(tl.int32)
+        c_desc.scatter(accumulator, scatter_idx, pid_n * BLOCK_SIZE_N)
+    else:
+        offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+        c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+        tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
 @triton.jit
@@ -175,6 +212,10 @@ def fused_moe_kernel_gptq_awq(
             BLOCK_SIZE_M,
             BLOCK_SIZE_N,
             compute_type,
+            num_valid_tokens,
+            # Quantized kernel: TD load/store path is not enabled, so the
+            # zero store stays on the pointer path.
+            USE_TD=False,
         )
         return
 
@@ -346,6 +387,9 @@ def fused_moe_kernel(
     per_channel_quant: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     SWAP_AB: tl.constexpr,
+    # Tensor-descriptor store path for write_zeros_to_output. False keeps
+    # the pointer path.
+    USE_TD: tl.constexpr = False,
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -430,6 +474,8 @@ def fused_moe_kernel(
             BLOCK_SIZE_M,
             BLOCK_SIZE_N,
             compute_type,
+            num_valid_tokens,
+            USE_TD=USE_TD,
         )
         return
 
@@ -764,6 +810,15 @@ def invoke_fused_moe_triton_kernel(
     else:
         SWAP_AB = False
 
+    use_td = resolve_moe_write_zeros_use_td()
+    if use_td:
+        # The TD store builds a tensor descriptor inside the kernel, which
+        # requires a PyTorch-backed scratch allocator to be registered
+        # (Triton raises "no allocator was set" otherwise on CUDA). Cached
+        # per device since triton.set_allocator is process-global state, not
+        # per-call configuration.
+        _set_triton_allocator_once(A.device)
+
     if use_fp8_w8a8 or use_int8_w8a8:
         assert B_scale is not None
         assert block_shape is None or triton.cdiv(
@@ -781,6 +836,14 @@ def invoke_fused_moe_triton_kernel(
 
     M = A.size(0)
     num_tokens = M * top_k
+    if use_td:
+        # write_zeros_to_output's TD scatter casts the row index
+        # (offs_token, which addresses num_valid_tokens rows) to int32.
+        assert num_tokens < 2**31, (
+            f"num_valid_tokens={num_tokens} exceeds int32 range; the TD "
+            "scatter path in write_zeros_to_output casts the row index to "
+            "int32, disable it with VLLM_TRITON_USE_TD=0"
+        )
     if sorted_token_ids is not None:
         EM = sorted_token_ids.size(0)
         if A.size(0) < config["BLOCK_SIZE_M"]:
@@ -846,6 +909,7 @@ def invoke_fused_moe_triton_kernel(
         HAS_BIAS=HAS_BIAS,
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         SWAP_AB=SWAP_AB,
+        USE_TD=use_td,
         **config,
     )
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -57,28 +57,16 @@ def write_zeros_to_output(
     BLOCK_SIZE_N,
     compute_type,
     num_valid_tokens,
-    # Tensor-descriptor store for the scattered zero write. False keeps the
-    # pointer path. When True, num_valid_tokens must fit in int32 (the
-    # scatter row index), enforced by the caller in
-    # invoke_fused_moe_triton_kernel.
+    # Scattered zero-write via tensor descriptor instead of masked pointer
+    # store. Requires num_valid_tokens to fit in int32 (enforced by the
+    # caller) and c_ptr to be contiguous/16-byte aligned (true for all
+    # current callers, unchecked).
     USE_TD: tl.constexpr = False,
 ):
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=compute_type)
     if USE_TD:
-        # C is viewed as a flat (num_valid_tokens, N) matrix; the zero block is
-        # scattered to the (non-contiguous) ``offs_token`` rows.
-        # ``tt.descriptor_scatter`` requires block_shape[0] == 1 and i32
-        # indices. Padded slots carry ``offs_token >= num_valid_tokens`` and
-        # are dropped by the descriptor's row-shape bound (the scatter API has
-        # no mask), so no out-of-bounds write occurs.
-        #
-        # Unasserted precondition: tl.make_tensor_descriptor requires the
-        # last dim to be contiguous (stride_cn == 1) and c_ptr to be
-        # 16-byte aligned. Every current caller passes a fresh contiguous
-        # cache with N a multiple of 128, so this holds today, but a
-        # future caller with a strided/unaligned C would silently
-        # miscompile or fail at compile time rather than fall back to the
-        # pointer path (which tolerates arbitrary strides).
+        # Padded slots (offs_token >= num_valid_tokens) are dropped by the
+        # descriptor's row-shape bound; the scatter API itself has no mask.
         c_desc = tl.make_tensor_descriptor(
             base=c_ptr,
             shape=(num_valid_tokens, N),
@@ -213,8 +201,6 @@ def fused_moe_kernel_gptq_awq(
             BLOCK_SIZE_N,
             compute_type,
             num_valid_tokens,
-            # Quantized kernel: TD load/store path is not enabled, so the
-            # zero store stays on the pointer path.
             USE_TD=False,
         )
         return
@@ -812,11 +798,7 @@ def invoke_fused_moe_triton_kernel(
 
     use_td = resolve_moe_write_zeros_use_td()
     if use_td:
-        # The TD store builds a tensor descriptor inside the kernel, which
-        # requires a PyTorch-backed scratch allocator to be registered
-        # (Triton raises "no allocator was set" otherwise on CUDA). Cached
-        # per device since triton.set_allocator is process-global state, not
-        # per-call configuration.
+        # tl.make_tensor_descriptor needs a registered allocator.
         _set_triton_allocator_once(A.device)
 
     if use_fp8_w8a8 or use_int8_w8a8:
@@ -837,12 +819,10 @@ def invoke_fused_moe_triton_kernel(
     M = A.size(0)
     num_tokens = M * top_k
     if use_td:
-        # write_zeros_to_output's TD scatter casts the row index
-        # (offs_token, which addresses num_valid_tokens rows) to int32.
+        # write_zeros_to_output's TD scatter casts the row index to int32.
         assert num_tokens < 2**31, (
-            f"num_valid_tokens={num_tokens} exceeds int32 range; the TD "
-            "scatter path in write_zeros_to_output casts the row index to "
-            "int32, disable it with VLLM_TRITON_USE_TD=0"
+            f"num_valid_tokens={num_tokens} exceeds int32 range for the TD "
+            "scatter path, disable it with VLLM_TRITON_USE_TD=0"
         )
     if sorted_token_ids is not None:
         EM = sorted_token_ids.size(0)

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import torch
 import torch.nn.functional as F
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
@@ -579,3 +580,68 @@ def enable_swap_ab(BLOCK_SIZE_M: int, BLOCK_SIZE_N: int) -> bool:
         and BLOCK_SIZE_M < 64
         and BLOCK_SIZE_N >= 64
     )
+
+
+def moe_write_zeros_td_hw_supported() -> bool:
+    """Whether the current device can run the TD path of
+    ``write_zeros_to_output`` (ignores the ``VLLM_TRITON_USE_TD`` override).
+
+    On CUDA, the TD path uses ``tensor_descriptor.scatter``, which lowers to
+    the PTX ``tile::scatter4`` instruction. That instruction is part of the
+    ``tcgen05``/Tensor Memory (TMEM) family introduced with Blackwell and has
+    no Hopper (sm90) equivalent -- ptxas rejects it there ("Feature
+    '.tile::scatter4' not supported on .target 'sm_90a'"). It is also
+    unsupported on consumer Blackwell (sm120/sm121, e.g. RTX 50-series, DGX
+    Spark): see triton-lang/triton#8498, which enables ``gather4`` on
+    sm120/sm121 but explicitly skips the ``scatter4`` test there ("unsupported
+    by hardware"). So this gates on the sm100 *family* specifically, not a
+    blanket ``>=100`` capability check -- mirrors the
+    ``has_tma_gather()``/``can_use_tma`` capability-gating pattern in
+    triton_kernels (triton-lang/triton#8484, fixing the identical class of
+    bug for gather4 on sm121, see triton-lang/triton#8335).
+
+    On XPU, `tensor_descriptor.scatter` has no equivalent hardware
+    instruction at all -- the Intel Triton backend's
+    ``triton-intel-rewrite-tensor-descriptor-to-pointer`` pass unconditionally
+    lowers every ``descriptor_scatter`` to a masked pointer store at the TTIR
+    level, for every XPU target (there is a single ``target_arch`` string
+    across generations, no per-generation dispatch in the backend as of the
+    triton-xpu version pinned in ``requirements/xpu.txt``). So unlike CUDA,
+    there's no hardware feature gap to gate on: the "TD path" on XPU is
+    always the same masked-store fallback the compiler would use anyway,
+    just reached through the tensor-descriptor API. If a future triton-xpu
+    release adds generation-conditional lowering for this op, this
+    blanket-enable will need revisiting.
+    """
+    if current_platform.is_xpu():
+        return True
+    if current_platform.is_cuda():
+        return current_platform.is_device_capability_family(100)
+    return False
+
+
+def resolve_moe_write_zeros_use_td() -> bool:
+    """Tri-state resolver for ``VLLM_TRITON_USE_TD``.
+
+    This flag is shared with the unified-attention TD path
+    (``vllm/v1/attention/backends/triton_attn.py``) -- setting it affects
+    both. Unset (default) keeps the pointer-store path everywhere for this
+    kernel: microbenchmarks of ``write_zeros_to_output`` in isolation showed
+    the TD path slower than the pointer path at all but the largest measured
+    problem size (+206%, +112%, +38% at three of four sizes; parity only at
+    the largest), so this is not auto-enabled by hardware capability alone.
+    ``1`` forces TD on, raising ``ValueError`` if the current hardware can't
+    run it (see ``moe_write_zeros_td_hw_supported``); ``0`` forces it off.
+    """
+    override = envs.VLLM_TRITON_USE_TD
+    if override is None:
+        return False
+    if override and not moe_write_zeros_td_hw_supported():
+        raise ValueError(
+            "VLLM_TRITON_USE_TD=1 forces the MoE write_zeros_to_output "
+            "tensor-descriptor scatter path on, but the current hardware "
+            "doesn't support tensor_descriptor.scatter (requires XPU or "
+            "NVIDIA Blackwell sm100 family). Unset VLLM_TRITON_USE_TD or "
+            "set it to 0."
+        )
+    return override

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -586,32 +586,16 @@ def moe_write_zeros_td_hw_supported() -> bool:
     """Whether the current device can run the TD path of
     ``write_zeros_to_output`` (ignores the ``VLLM_TRITON_USE_TD`` override).
 
-    On CUDA, the TD path uses ``tensor_descriptor.scatter``, which lowers to
-    the PTX ``tile::scatter4`` instruction. That instruction is part of the
-    ``tcgen05``/Tensor Memory (TMEM) family introduced with Blackwell and has
-    no Hopper (sm90) equivalent -- ptxas rejects it there ("Feature
-    '.tile::scatter4' not supported on .target 'sm_90a'"). It is also
-    unsupported on consumer Blackwell (sm120/sm121, e.g. RTX 50-series, DGX
-    Spark): see triton-lang/triton#8498, which enables ``gather4`` on
-    sm120/sm121 but explicitly skips the ``scatter4`` test there ("unsupported
-    by hardware"). So this gates on the sm100 *family* specifically, not a
-    blanket ``>=100`` capability check -- mirrors the
-    ``has_tma_gather()``/``can_use_tma`` capability-gating pattern in
-    triton_kernels (triton-lang/triton#8484, fixing the identical class of
-    bug for gather4 on sm121, see triton-lang/triton#8335).
+    CUDA: ``tensor_descriptor.scatter`` lowers to PTX ``tile::scatter4``
+    (tcgen05/TMEM), unsupported on Hopper (sm90) and consumer Blackwell
+    (sm120/sm121, triton-lang/triton#8498) -- gated on the sm100 family
+    specifically, not a blanket ``>=100`` check.
 
-    On XPU, `tensor_descriptor.scatter` has no equivalent hardware
-    instruction at all -- the Intel Triton backend's
-    ``triton-intel-rewrite-tensor-descriptor-to-pointer`` pass unconditionally
-    lowers every ``descriptor_scatter`` to a masked pointer store at the TTIR
-    level, for every XPU target (there is a single ``target_arch`` string
-    across generations, no per-generation dispatch in the backend as of the
-    triton-xpu version pinned in ``requirements/xpu.txt``). So unlike CUDA,
-    there's no hardware feature gap to gate on: the "TD path" on XPU is
-    always the same masked-store fallback the compiler would use anyway,
-    just reached through the tensor-descriptor API. If a future triton-xpu
-    release adds generation-conditional lowering for this op, this
-    blanket-enable will need revisiting.
+    XPU: no gating needed. The Intel Triton backend always rewrites
+    ``descriptor_scatter`` to a masked pointer store at the TTIR level,
+    regardless of generation, so the "TD path" is just the same fallback
+    reached through a different API. Revisit if a future triton-xpu
+    release adds generation-conditional lowering for this op.
     """
     if current_platform.is_xpu():
         return True
@@ -621,17 +605,11 @@ def moe_write_zeros_td_hw_supported() -> bool:
 
 
 def resolve_moe_write_zeros_use_td() -> bool:
-    """Tri-state resolver for ``VLLM_TRITON_USE_TD``.
-
-    This flag is shared with the unified-attention TD path
-    (``vllm/v1/attention/backends/triton_attn.py``) -- setting it affects
-    both. Unset (default) keeps the pointer-store path everywhere for this
-    kernel: microbenchmarks of ``write_zeros_to_output`` in isolation showed
-    the TD path slower than the pointer path at all but the largest measured
-    problem size (+206%, +112%, +38% at three of four sizes; parity only at
-    the largest), so this is not auto-enabled by hardware capability alone.
-    ``1`` forces TD on, raising ``ValueError`` if the current hardware can't
-    run it (see ``moe_write_zeros_td_hw_supported``); ``0`` forces it off.
+    """Tri-state resolver for ``VLLM_TRITON_USE_TD``, shared with the
+    unified-attention TD path. Unset defaults to off for this kernel (see
+    ``benchmarks/kernels/benchmark_moe_write_zeros_td.py``); ``1`` forces TD
+    on, raising ``ValueError`` if unsupported (see
+    ``moe_write_zeros_td_hw_supported``); ``0`` forces it off.
     """
     override = envs.VLLM_TRITON_USE_TD
     if override is None:


### PR DESCRIPTION
## Test PR — for review before submitting upstream

Test PR against my own fork's `main`, opened for review before submitting to `vllm-project/vllm`. Not intended to merge here.

## Summary

- Adds a TD (tensor-descriptor) path to `write_zeros_to_output`, the MoE zero-store helper for EP-pruned expert blocks (`off_experts == -1`).
- Store-side dual of the TD *load* pattern used elsewhere in the Triton MoE TD work — uses `tensor_descriptor.scatter()` instead of pointer + mask.
- Gated by `USE_TD` constexpr / `VLLM_TRITON_USE_TD` env var (tri-state: unset=auto, `1`/`0`=force). This flag is shared with the unified-attention TD path (`triton_attn.py`) — setting it affects both kernels, there's no independent control. Default (unset) is **off** for this path specifically: see Performance below.

## Hardware gating

- CUDA: `tensor_descriptor.scatter` lowers to PTX `tile::scatter4` (tcgen05/TMEM family) — no Hopper (sm90) equivalent, and unsupported on consumer Blackwell (sm120/121) per triton-lang/triton#8498. Gated on `is_device_capability_family(100)` (sm100 family, not blanket `>=100`).
- XPU: unconditionally supported. Unlike CUDA there's no hardware feature gap — the Intel Triton backend's `triton-intel-rewrite-tensor-descriptor-to-pointer` pass unconditionally lowers `descriptor_scatter` to a masked pointer store at the TTIR level for every XPU target (single `target_arch`, no per-generation dispatch as of the triton-xpu version this repo pins). See `moe_write_zeros_td_hw_supported()` docstring for the full argument and its limits.
- Forcing `VLLM_TRITON_USE_TD=1` on unsupported hardware now raises `ValueError` at call time (previously failed lazily at ptxas with an opaque compiler error) — verified on H200 (Hopper), see table below.

## Performance (kernel-level microbenchmark) — why this defaults to off

Standalone microbenchmark isolating `write_zeros_to_output` via a thin launcher (no GEMM, no `fused_moe()` overhead), checked into `benchmarks/kernels/benchmark_moe_write_zeros_td.py` (`triton.testing.do_bench`, median of 3 process-level repeats). Measures the store-path cost in isolation, not an E2E throughput claim.

| m | n | k | pointer (µs) | TD (µs) | Δ% |
|---|---|---|---|---|---|
| 83 | 512 | 256 | 6.29 | 19.29 | +206.6% |
| 1 | 1024 | 512 | 6.94 | 14.72 | +112.0% |
| 2048 | 4096 | 4096 | 19.50 | 26.91 | +38.0% |
| 8192 | 4096 | 4096 | 58.19 | 58.81 | +1.1% |

XPU (Battlemage B70). TD is slower than the pointer path at every measured size — only converging to parity (+1.1%) at the largest, most EP-realistic batch. **This is a consistency change (store-side dual of the existing TD load work), not a perf win** — the TD path defaults to off (`resolve_moe_write_zeros_use_td()` returns `False` unless `VLLM_TRITON_USE_TD=1` is set explicitly), available for forced A/B testing but not auto-enabled by hardware capability. (The benchmark's `PROBLEM_SIZES` were subsequently updated to real Mixtral-8x7B / DeepSeek-V3 dims per review; the numbers above are from the original illustrative sizes and will be refreshed on the next run.)

## Correctness testing

The original all-pruned test (`test_fused_moe_all_experts_pruned`, asserting `fused_moe()` output is all-zero) doesn't actually exercise the scatter: `fused_experts_impl` pre-zeros `intermediate_cache3` in Python (`intermediate_cache3.zero_()`) whenever `expert_map is not None`, before either store path runs — so a correct scatter, a no-op, and a wrong-row scatter are all indistinguishable at that assertion. Added `test_write_zeros_to_output_scatter_targets_correct_rows`, which calls `write_zeros_to_output` directly through a thin launcher with a non-zero sentinel pre-filled *before* the kernel runs, and asserts both that valid rows are zeroed and that the out-of-bounds guard row is untouched. Includes a non-block-aligned N (104, not a multiple of BLOCK_SIZE_N=64) to cover the TD descriptor's column-bound clamp on a tail tile.

Kept the original all-pruned and mixed-EP end-to-end tests as coarser whole-pipeline sanity checks, with docstrings noting they can't detect a scatter-targeting defect on their own.

## Verified on real hardware (2026-07-17, this revision)

XPU (B70) and H200 (Hopper) were re-run against this revision's code, including the new sentinel-based scatter test. B200 (Blackwell sm100) could not be re-run this round — the B200 host was cluster-loaded (load avg >130, no card at genuine 0 MiB free) throughout the window; the prior-revision B200 rows are retained below and marked as such.

| Platform | Card | Test | Result |
|---|---|---|---|
| XPU | B70 | `test_write_zeros_to_output_scatter_targets_correct_rows` (6 cases) | **6/6 pass** — the sentinel-based scatter test, the one that can actually catch a wrong-row/no-op scatter |
| XPU | B70 | `test_fused_moe_all_experts_pruned` (4 cases) | 4/4 pass |
| XPU | B70 | `test_fused_moe_all_experts_pruned_int64_overflow` (2 cases) | 2/2 pass |
| XPU | B70 | `resolve_moe_write_zeros_use_td()` gating | unset → `False` (default off); forced `=1` on XPU → `True`, no raise |
| GPU | H200 (Hopper) | `test_write_zeros_to_output_scatter_targets_correct_rows` (6 cases) | 3 pass (`use_td=False`) + 3 skipped (`use_td=True`, correctly gated off sm90) |
| GPU | H200 (Hopper) | `test_fused_moe_mixed_ep_td_matches_pointer` (2 cases) | 2 skipped (correctly gated off sm90) |
| GPU | H200 (Hopper) | `test_fused_moe_all_experts_pruned` (4 cases) | 2 pass + 2 skipped |
| GPU | H200 (Hopper) | `test_fused_moe_all_experts_pruned_int64_overflow` (2 cases) | 1 pass + 1 skipped |
| GPU | H200 (Hopper) | `VLLM_TRITON_USE_TD=1` fail-fast | raises `ValueError` with the expected message (unsupported-hardware guard works) |

Prior-revision runs (before this round's review fixes), retained for reference:

| Platform | Card | Test | Result |
|---|---|---|---|
| XPU | B70 | mixed-EP TD-vs-pointer cross-check (standalone script) | bit-identical (`max diff = 0.0`) |
| GPU | B200 (Blackwell) | `test_fused_moe_all_experts_pruned` (4 cases) | 4/4 pass, through the real `fused_moe_kernel` |
| GPU | B200 (Blackwell) | `test_fused_moe_all_experts_pruned_int64_overflow` (2 cases) | 2/2 pass, both `use_td` values |
| GPU | B200 (Blackwell) | mixed-EP TD-vs-pointer cross-check (standalone script) | bit-identical (`max diff = 0.0`) |
| GPU | B200 (Blackwell) | NVFP4-emulation all-pruned probe | compiles + runs after third-caller fix |

**Still outstanding before upstream-ready:**
- `test_write_zeros_to_output_scatter_targets_correct_rows` and `test_fused_moe_mixed_ep_td_matches_pointer` have not been run on B200 (sm100) *in this test form* — B200 is the only CUDA host where the TD scatter code path actually executes rather than skips, so the CUDA-side TD scatter is currently validated only by the prior-revision standalone cross-check, not the checked-in test. Needs a B200 pass when the cluster frees up.
- Benchmark `PROBLEM_SIZES` (now real model dims) not yet re-run; Performance table above still reflects the original illustrative sizes.

## Test-harness notes found while running

- `test_fused_moe_mixed_ep_td_matches_pointer[1-1024-512]` initially failed on B70 — but on its own precondition (`count_nonzero(out_pointer) > 0`), not the TD-vs-pointer comparison: with `m=1`, random top-k routing can select only pruned experts for the single token, yielding a legitimately all-zero pointer-path baseline. Fixed by biasing one local expert's score so it's always selected (commit "Fix flaky non-zero precondition in mixed-EP TD test"). Not a kernel defect.
- On XPU, the pre-built container's baked `LD_LIBRARY_PATH` omits `/opt/intel/oneapi/umf/.../lib` and `.../tcm/.../lib`, which the Level-Zero loader needs — without them `torch.xpu.device_count()` returns 0 despite `zeInit` succeeding. Environment issue, not a code issue; flagged here for anyone reproducing on XPU.

## Test plan

- `test_write_zeros_to_output_scatter_targets_correct_rows` (new): direct sentinel-based test of the scatter — **6/6 pass on B70; 3 pass + 3 correct-skip on H200** (see table). Not yet run on B200.
- `test_fused_moe_all_experts_pruned` (existing): coarse smoke test, all-pass on B70 / pass+skip on H200.
- `test_fused_moe_all_experts_pruned_int64_overflow` (existing): pass on B70 / pass+skip on H200.
- `test_fused_moe_mixed_ep_td_matches_pointer` (new checked-in test): skips on H200 (sm90). Not yet run on B200 in this form; prior-revision standalone cross-check was bit-identical on B70 + B200.
- `ruff check` + `ruff format --check` + local `pre-commit` clean on all modified files.

AI assistance was used (Claude Code) for implementation and testing. I reviewed every changed line; the 2026-07-17 XPU/H200 rows were run against this revision, the B200 rows are from a prior revision and B200 re-run on this revision is still pending.
