### PR TITLE
attention: hoist Q-scale multiply out of unified attention tile loop

### DIFF
--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -534,12 +534,22 @@ def kernel_unified_attention(
 
         # S : (BLOCK_M, TILE_SIZE)
         S = tl.zeros(shape=(BLOCK_M, TILE_SIZE), dtype=tl.float32)
-        if USE_PER_TOKEN_HEAD_SCALES:
-            # Per-token-head quant: fuse softmax_scale with per-head k_scale
-            # to avoid a separate BLOCK_M × TILE_SIZE multiply on S.
-            S += tl.dot(Q, K) * (score_scale * k_token_head_scales[None, :])
-        else:
+        if USE_FP8_Q_DESCALE:
+            # fp8 query: score_scale = scale * q_scale * k_scale (~1e-2).
+            # Folding it into Q and casting back to Q.dtype (fp8) would
+            # requantize the product and destroy precision, so keep the
+            # scale on S here.
             S += score_scale * tl.dot(Q, K)
+        else:
+            # Reassociate so ``score_scale * Q`` is loop-invariant: the
+            # compiler hoists the multiply out of the tile loop instead of
+            # scaling the BLOCK_M × TILE_SIZE S matrix on every iteration.
+            Q_scaled = (Q * score_scale).to(Q.dtype)
+            if USE_PER_TOKEN_HEAD_SCALES:
+                # Per-token-head quant: per-head k_scale still multiplies S.
+                S += tl.dot(Q_scaled, K) * k_token_head_scales[None, :]
+            else:
+                S += tl.dot(Q_scaled, K)
 
         if USE_SOFTCAP:
             S = apply_softcap(S, softcap)


### PR DESCRIPTION
## Summary
Port of [intel/intel-xpu-backend-for-triton#7193](https://github.com/intel/intel-xpu-backend-for-triton/pull/7193) to vLLM's `triton_unified_attention.py`. Reassociates the softmax score scaling so `score_scale * Q` becomes a loop-invariant expression (`Q_scaled = (Q * score_scale).to(Q.dtype)`), letting the compiler hoist the multiply out of the per-tile loop instead of scaling the `BLOCK_M x TILE_SIZE` `S` matrix on every iteration.

Intel measured +1.26x bf16 / +1.14x fp8-KV geomean on their unified attention benchmark (XPU).

The `USE_FP8_Q_DESCALE` path is deliberately excluded from the reassociation: there `score_scale = scale * q_scale * k_scale` (~1e-2), so folding it into Q and casting back to `Q.dtype` (fp8) would requantize the product and destroy precision. That path keeps the scale on `S`.

## Known issue on Triton-XPU 3.7.1 (context, not blocking this PR)
On Intel's Triton-XPU 3.7.1, this reassociation combined with the tensor-descriptor Q-load path (`USE_TD_QO=True`, head_size=128) produces garbage output — `(descriptor_Q * scale).to(bf16)` feeding `tl.dot` miscompiles. That is an Intel-backend codegen bug, tracked separately; it does not touch AMD/NVIDIA code paths (Intel's own compiler pass for the equivalent optimization, [PR#7220](https://github.com/intel/intel-xpu-backend-for-triton/pull/7220), lives entirely under `third_party/intel/` and is fast-math-gated).

## This PR (fork-only, not yet for upstream)
Opened as a **draft on the fork** to validate on NVIDIA hardware before deciding whether to send upstream. No XPU tensor-descriptor path is enabled by default in vLLM's kernel, so this is exercising the reassociation on the standard (non-TD) path here.

## Test plan
- [ ] `pytest tests/kernels/attention/test_triton_unified_attention.py` on NVIDIA (bf16, fp8-KV per-tensor, fp8 per-token-head paths)
- [ ] `vllm bench` perf sweep on NVIDIA (H200/B200) — check for regression vs baseline, not just parity
- [ ] Confirm `USE_FP8_Q_DESCALE` path numerically unaffected (should be, since untouched)

Co-authored-by: Quinn Pham <quinn.pham@intel.com>