### PR TITLE
attention: hoist Q-scale multiply out of unified attention tile loop

### DIFF
--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -534,12 +534,22 @@ def kernel_unified_attention(
 
         # S : (BLOCK_M, TILE_SIZE)
         S = tl.zeros(shape=(BLOCK_M, TILE_SIZE), dtype=tl.float32)
-        if USE_PER_TOKEN_HEAD_SCALES:
-            # Per-token-head quant: fuse softmax_scale with per-head k_scale
-            # to avoid a separate BLOCK_M × TILE_SIZE multiply on S.
-            S += tl.dot(Q, K) * (score_scale * k_token_head_scales[None, :])
-        else:
+        if USE_FP8_Q_DESCALE:
+            # fp8 query: score_scale = scale * q_scale * k_scale (~1e-2).
+            # Folding it into Q and casting back to Q.dtype (fp8) would
+            # requantize the product and destroy precision, so keep the
+            # scale on S here.
             S += score_scale * tl.dot(Q, K)
+        else:
+            # Reassociate so ``score_scale * Q`` is loop-invariant: the
+            # compiler hoists the multiply out of the tile loop instead of
+            # scaling the BLOCK_M × TILE_SIZE S matrix on every iteration.
+            Q_scaled = (Q * score_scale).to(Q.dtype)
+            if USE_PER_TOKEN_HEAD_SCALES:
+                # Per-token-head quant: per-head k_scale still multiplies S.
+                S += tl.dot(Q_scaled, K) * k_token_head_scales[None, :]
+            else:
+                S += tl.dot(Q_scaled, K)
 
         if USE_SOFTCAP:
             S = apply_softcap(S, softcap)


### PR DESCRIPTION
## Summary
Port of [intel/intel-xpu-backend-for-triton#7193](https://github.com/intel/intel-xpu-backend-for-triton/pull/7193) to vLLM's `triton_unified_attention.py`. Reassociates the softmax score scaling so `score_scale * Q` becomes a loop-invariant expression (`Q_scaled = (Q * score_scale).to(Q.dtype)`), letting the compiler hoist the multiply out of the per-tile loop instead of scaling the `BLOCK_M x TILE_SIZE` `S` matrix on every iteration.

Intel measured +1.26x bf16 / +1.14x fp8-KV geomean on their unified attention benchmark (XPU).

The `USE_FP8_Q_DESCALE` path is deliberately excluded from the reassociation: there `score_scale = scale * q_scale * k_scale` (~1e-2), so folding it into Q and casting back to `Q.dtype` (fp8) would requantize the product and destroy precision. That path keeps the scale on `S`.

## Known issue on Triton-XPU 3.7.1 — UPDATE: no longer reproduces on current environments
On an older Triton-XPU 3.7.1 environment, this reassociation combined with the tensor-descriptor Q-load path (`USE_TD_QO=True`, head_size=128) was observed to produce garbage output — `(descriptor_Q * scale).to(bf16)` feeding `tl.dot` miscompiled. Further investigation traced this to the Intel Graphics Compiler (IGC) version bundled in that older environment, not to the Triton version or to this PR's kernel change. On a current environment (newer IGC), the full `test_triton_unified_attention.py` suite — including the TD-Q head_size=128 cases — passes cleanly with this patch applied. See the Validation results section below for the actual test run this PR now carries. As before, this compiler-level issue is Intel-backend-specific and does not touch AMD/NVIDIA code paths (Intel's own compiler pass for the equivalent optimization, [PR#7220](https://github.com/intel/intel-xpu-backend-for-triton/pull/7220), lives entirely under `third_party/intel/` and is fast-math-gated).

## This PR (fork-only, not yet for upstream)
Opened as a **draft on the fork** to validate before deciding whether to send upstream. Originally scoped to NVIDIA-only validation; broadened to include Intel XPU as well (see Validation results). No XPU tensor-descriptor path is enabled by default in vLLM's kernel, so this is exercising the reassociation on the standard (non-TD) path on both platforms.

## Test plan
- [x] `pytest tests/kernels/attention/test_triton_unified_attention.py` on NVIDIA and Intel XPU (bf16, fp8-KV per-tensor, fp8 per-token-head paths)
- [x] `vllm bench` perf sweep on NVIDIA (H200) and Intel XPU (B70) — checked for regression vs baseline
- [x] Confirmed `USE_FP8_Q_DESCALE` path numerically unaffected (untouched code path passes identically to baseline)

Co-authored with Quinn Pham (attribution recorded in the commit trailer).

## Validation results (2026-07-10)

Validated on the current commit (`58a2c6857`, rebased onto fresh vLLM `main`) vs. its immediate parent (baseline, pre-patch). Reduced pilot scope: one model (`meta-llama/Llama-3.1-8B-Instruct`), one perf dataset (`sharegpt`), one accuracy task (`gsm8k`), on Intel B70 and NVIDIA H200.

### Correctness — `tests/kernels/attention/test_triton_unified_attention.py`

| Platform | Baseline | Patched |
|---|---|---|
| Intel B70 (XPU) | 1874 passed, 0 failed | 1874 passed, 0 failed |
| NVIDIA H200 | 1584 passed, 290 failed* | 1584 passed, 290 failed* (identical failure set) |

\* All 290 H200 failures are `test_triton_unified_attn_use_td*` cases, failing identically on both baseline and patched — a pre-existing stock-Triton-3.6.0/CUDA-13 TMA-pipeliner incompatibility, unrelated to this PR (TD is not auto-enabled on CUDA, and this diff doesn't touch the TD code path). The 1584 non-TD tests, which do exercise this PR's diff (including the untouched `USE_FP8_Q_DESCALE` path), pass identically on both variants on both platforms.

### Performance — `vllm bench sweep serve` (sharegpt, seed=42, prefix caching off, N=3 median)

| Platform | Baseline median | Patched median | Δ | Verdict |
|---|---|---|---|---|
| Intel B70 (1000 prompts) | 683.09 tok/s | 677.60 tok/s | 0.80% | within run-to-run noise (noise band up to 12.9%) |
| NVIDIA H200 (12000 prompts) | 42.52 req/s | 42.52 req/s | 0.02% | within run-to-run noise (noise band up to 14.3%) |

No measurable E2E throughput difference on either platform. Consistent with the change's scope — a single-instruction reassociation inside one kernel's per-tile loop, whose effect is best measured at the kernel-microbenchmark level (the +1.26x/+1.14x geomean cited above), not necessarily visible at E2E serve throughput where attention is one of several kernels on the critical path.

### Accuracy — `lm-eval`, gsm8k, vLLM engine (5-shot default harness config)

| Platform | Baseline (strict-match / flexible-extract) | Patched (strict-match / flexible-extract) |
|---|---|---|
| Intel B70 | 0.700 / 0.773 | 0.708 / 0.773 |
| NVIDIA H200 | 0.703 / 0.775 | 0.704 / 0.775 |

All deltas are within 1 stderr on a 1319-sample set. No accuracy regression on either platform. (Model-card-reported gsm8k for this model is 84.5% under an 8-shot CoT protocol — not directly comparable to the 5-shot default harness numbers above; included only as a sanity range check.)
