### PR TITLE
[Bugfix] Fail loudly on unregistered checkpoint tensors in fused linear load_weights

### DIFF
--- a/tests/model_executor/layers/test_linear_load_weights.py
+++ b/tests/model_executor/layers/test_linear_load_weights.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for MergedColumnParallelLinear/QKVParallelLinear
+.load_weights() handling checkpoint tensors the layer never registered.
+
+``getattr(self, name, self)`` used the layer itself as a "not found"
+sentinel, so a tensor with no registered param fell through to
+``param.weight_loader(param, ...)`` with ``param`` bound to the whole layer
+module, crashing with ``AttributeError: ... has no attribute 'data'`` deep
+inside ``weight_loader``.
+
+The pre-existing ``param is None and name == "bias"`` guard already covered a
+bare ``bias``: ``ColumnParallelLinear`` calls ``register_parameter("bias",
+None)`` when ``bias=False``, so ``getattr`` returns None rather than the
+sentinel. The sentinel was reachable only for genuinely absent attributes, and
+every one of those is a real mismatch between checkpoint and quantization
+config -- so the tests below pin that such a tensor produces a diagnosable
+``ValueError`` naming the layer, instead of the opaque ``AttributeError``.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+)
+
+
+def test_merged_column_parallel_load_weights_raises_on_unregistered_g_idx(
+    dist_init, default_vllm_config
+):
+    layer = MergedColumnParallelLinear(
+        4, [2, 2], bias=False, params_dtype=torch.float16
+    )
+    assert not hasattr(layer, "g_idx"), "premise: g_idx must be unregistered"
+
+    # An unquantized layer has no use for an activation-order permutation, so
+    # receiving one means the config and the checkpoint disagree. That must be
+    # reported, not skipped: skipping would run the layer on weights whose row
+    # order was never applied.
+    with pytest.raises(ValueError, match="does not match any parameter"):
+        list(layer.load_weights([("g_idx", torch.zeros(4, dtype=torch.int32))]))
+
+
+def test_qkv_parallel_load_weights_raises_on_unregistered_g_idx(
+    dist_init, default_vllm_config
+):
+    layer = QKVParallelLinear(4, 2, 2, bias=False, params_dtype=torch.float16)
+    assert not hasattr(layer, "g_idx"), "premise: g_idx must be unregistered"
+
+    with pytest.raises(ValueError, match="does not match any parameter"):
+        list(layer.load_weights([("g_idx", torch.zeros(4, dtype=torch.int32))]))
+
+
+def test_merged_column_parallel_load_weights_raises_on_unregistered_qweight(
+    dist_init, default_vllm_config
+):
+    layer = MergedColumnParallelLinear(
+        4, [2, 2], bias=False, params_dtype=torch.float16
+    )
+    assert not hasattr(layer, "qweight"), "premise: qweight must be unregistered"
+
+    with pytest.raises(ValueError, match="does not match any parameter"):
+        list(layer.load_weights([("qweight", torch.zeros(2, 2, dtype=torch.int32))]))
+
+
+def test_merged_column_parallel_load_weights_error_names_layer_and_tensor(
+    dist_init, default_vllm_config
+):
+    layer = MergedColumnParallelLinear(
+        4, [2, 2], bias=False, params_dtype=torch.float16, prefix="model.layers.0.mlp"
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        list(layer.load_weights([("input_scale", torch.zeros(1))]))
+
+    message = str(excinfo.value)
+    assert "input_scale" in message
+    assert "MergedColumnParallelLinear" in message
+    assert "model.layers.0.mlp" in message
+
+
+def test_merged_column_parallel_load_weights_skips_submodule_bias_none(
+    dist_init, default_vllm_config
+):
+    layer = MergedColumnParallelLinear(
+        4, [2, 2], bias=False, params_dtype=torch.float16
+    )
+    # A dotted name resolves through the submodule, and `nn.Linear(bias=False)`
+    # registers `bias` as None there too. Before the shared helper the skip
+    # compared the full dotted name against the literal "bias", so this crashed
+    # with `AttributeError: 'NoneType' object has no attribute 'weight_loader'`.
+    layer.add_module("sub", torch.nn.Linear(2, 2, bias=False))
+    assert layer.sub.bias is None, "premise: submodule bias must be None"
+
+    loaded = list(layer.load_weights([("sub.bias", torch.zeros(2))]))
+
+    assert loaded == []
+
+
+def test_merged_column_parallel_load_weights_skips_bias_registered_as_none(
+    dist_init, default_vllm_config
+):
+    layer = MergedColumnParallelLinear(
+        4, [2, 2], bias=False, params_dtype=torch.float16
+    )
+    # bias=False registers the param as None rather than omitting it.
+    assert layer.bias is None, "premise: bias must be registered as None"
+
+    # Pre-existing behaviour, preserved -- passes on unpatched main too.
+    loaded = list(layer.load_weights([("bias", torch.zeros(2))]))
+
+    assert loaded == []
+
+
+def test_merged_column_parallel_load_weights_loads_matched_weight(
+    dist_init, default_vllm_config
+):
+    layer = MergedColumnParallelLinear(
+        4, [2, 2], bias=False, params_dtype=torch.float16
+    )
+    weight = torch.rand(2, 4, dtype=torch.float16)
+    weight.shard_id = 0
+
+    # Pre-existing behaviour, preserved -- passes on unpatched main too.
+    loaded = list(layer.load_weights([("weight", weight)]))
+
+    assert loaded == ["weight"]

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -71,6 +71,15 @@ def register_weight_loader_v2_supported_method(cls):
     return cls
 
 
+# Checkpoint tensors a layer may legitimately leave unregistered, and which are
+# therefore safe to skip rather than load. `bias` is the only such name today:
+# `ColumnParallelLinear` calls `register_parameter("bias", None)` when built with
+# `bias=False`, while exporters emit the tensor anyway. Every other unregistered
+# tensor carries information (a scale, a permutation, packed weights) that the
+# layer would silently run without, so it is rejected instead of skipped.
+_OPTIONAL_CHECKPOINT_TENSORS = frozenset(("bias",))
+
+
 def adjust_marlin_shard(
     param: Parameter,
     shard_size: int,
@@ -81,6 +90,47 @@ def adjust_marlin_shard(
         return shard_size, shard_offset
 
     return shard_size * marlin_tile_size, shard_offset * marlin_tile_size
+
+
+def _resolve_loadable_param(
+    layer: torch.nn.Module,
+    name: str,
+) -> Parameter | None:
+    """Resolve a checkpoint tensor name to the param it loads into.
+
+    Returns None for a tensor the caller should skip, i.e. a `bias` on a layer
+    built with `bias=False`. The allowlist is deliberately limited to that one
+    name: skipping anything else would drop information the layer needs and let
+    it run with silently wrong numerics, so unknown names are rejected instead.
+
+    Raises:
+        ValueError: if `name` is neither a registered param nor a known
+            optional tensor, since loading it would otherwise fail deep
+            inside `weight_loader` with an opaque AttributeError.
+    """
+    if "." in name:
+        submodule, _, attr = name.rpartition(".")
+        target = layer.get_submodule(submodule)
+    else:
+        attr = name
+        target = layer
+
+    # `register_parameter(name, None)` is how an unused optional param is
+    # declared, so absent and registered-as-None both mean "nothing to load".
+    param = getattr(target, attr, None)
+    if param is not None:
+        return param
+
+    if attr in _OPTIONAL_CHECKPOINT_TENSORS:
+        return None
+
+    raise ValueError(
+        f"Checkpoint tensor '{name}' does not match any parameter registered "
+        f"on {type(layer).__name__} '{layer.prefix}', so the checkpoint and the "
+        "layer's quantization config disagree. Add the name to "
+        "_OPTIONAL_CHECKPOINT_TENSORS only if this layer genuinely does not "
+        "consume the tensor."
+    )
 
 
 def adjust_block_scale_shard(
@@ -942,14 +992,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         for name, loaded_weight in weights:
             shard_id = getattr(loaded_weight, "shard_id", None)
             self.validate_shard_id(shard_id)
-            # Load into self if name is not an attr of self or its submodules
-            param: Parameter
-            if "." in name:
-                submodule, _, attr = name.rpartition(".")
-                param = getattr(self.get_submodule(submodule), attr, self)
-            else:
-                param = getattr(self, name, self)
-            if param is None and name == "bias":
+            param = _resolve_loadable_param(self, name)
+            if param is None:
                 continue
             param.weight_loader(param, loaded_weight, shard_id)
             logger.debug(
@@ -1296,14 +1340,8 @@ class QKVParallelLinear(ColumnParallelLinear):
         for name, loaded_weight in weights:
             shard_id = getattr(loaded_weight, "shard_id", None)
             self.validate_shard_id(shard_id)
-            # Load into self if name is not an attr of self or its submodules
-            param: Parameter
-            if "." in name:
-                submodule, _, attr = name.rpartition(".")
-                param = getattr(self.get_submodule(submodule), attr, self)
-            else:
-                param = getattr(self, name, self)
-            if param is None and name == "bias":
+            param = _resolve_loadable_param(self, name)
+            if param is None:
                 continue
             param.weight_loader(param, loaded_weight, shard_id)
             logger.debug(


### PR DESCRIPTION
## Summary

`MergedColumnParallelLinear.load_weights()` and `QKVParallelLinear.load_weights()` used the layer module itself as a "not found" sentinel:

```python
param = getattr(self.get_submodule(submodule), attr, self)   # <- self as sentinel
...
if param is None and name == "bias":
    continue
param.weight_loader(param, loaded_weight, shard_id)
```

A checkpoint tensor with no registered param therefore reached `param.weight_loader()` with `param` bound to the *layer*, and crashed inside the loader with an opaque `AttributeError: 'QKVParallelLinear' object has no attribute 'data'`.

Both implementations were byte-identical, so name resolution and the skip/raise decision now live in one helper, `_resolve_loadable_param()`. A `bias` the layer registered as None is skipped, exactly as before; every other unregistered tensor raises a `ValueError` naming the layer and the tensor.

Three things change for a reader of the code, so this is not a rename: an unloadable checkpoint tensor now reports *which* layer and *which* tensor instead of `has no attribute 'data'`; a dotted `sub.bias` that `main` crashes on is handled; and the duplicated resolution block is gone from both classes.

## What the skip set actually is (measured, not assumed)

An earlier revision of this PR skipped three names — `bias`, `g_idx`, `g_idx_sort_indices` — and justified the last two with "GPTQ exporters emit them even when `desc_act=False`". **That justification was wrong and the two entries were dead code.** I instrumented `_resolve_loadable_param` and loaded a real `desc_act=False` GPTQ checkpoint (`Qwen/Qwen1.5-MoE-A2.7B-Chat-GPTQ-Int4`, bits=4, group_size=128) with the engine in-process so the spy observes the loading code:

```
SPY create_weights (layer, g_idx registered) -> {('QKVParallelLinear', True): 24,
                                                 ('MergedColumnParallelLinear', True): 24,
                                                 ('RowParallelLinear', True): 48}
SPY resolve: param found -> {'g_idx': 120, 'qweight': 120, 'qzeros': 120, 'scales': 120, 'bias': 72}
SPY resolve: skipped (None) -> {'bias': 48}
SPY resolve total calls: 600
```

`AutoGPTQLinearMethod.create_weights` registers `g_idx` unconditionally (`auto_gptq.py` — only the kernel config gets `has_g_idx=desc_act`), so `g_idx` resolves to a real `RowvLLMParameter` 120/120 times and can never reach the skip branch. `g_idx_sort_indices` never appears at all: for a linear layer its only producer is `marlin_sort_g_idx` in `process_weights_after_loading`, so it is not a checkpoint key. `bias` is the one name that actually fires (48 skips).

The allowlist is therefore `frozenset(("bias",))` — exactly the reachable set — and it is the same set upstream already skipped. I verified the `g_idx` registration on each platform separately, because kernel selection is platform-dependent:

| platform | `QKVParallelLinear` params with `desc_act=False` |
|---|---|
| H200 NVL (sm90) | `['g_idx', 'qweight', 'qzeros', 'scales']` |
| B200 (sm100) | `['g_idx', 'qweight', 'qzeros', 'scales']` |
| Intel Arc Pro B-series (XPU) | `['g_idx', 'qweight', 'qzeros', 'scales']` |

## Behavior change, stated

For a checkpoint carrying an unregistered tensor other than `bias`, this raises `ValueError` where `main` raises `AttributeError` from inside `weight_loader`. **Both are hard failures** — such a load never succeeded — so this changes the diagnostic, not whether any model loads.

One case flips from crash to skip: a dotted name such as `sub.bias`, resolving to a submodule param registered as None. `main` compared the *full* name against the literal `"bias"`, so it fell through and died on `AttributeError: 'NoneType' object has no attribute 'weight_loader'`; the helper compares the resolved attribute name and skips it. There is a test for it. I have not seen a checkpoint that reaches this, so I am not claiming it as the motivating bug.

## Why it raises instead of skipping more names

Names that genuinely can reach the raise are ones where skipping would be *wrong*, not harmless:

- compressed-tensors W4A16 `weight_g_idx` (registered only when `actorder == GROUP`) — dropping it runs the layer on weights whose row permutation was never applied.
- fp8 `input_scale` (registered only when `activation_scheme == "static"`) — dropping it silently discards the activation scale.

Both currently fail on `main` with the opaque `AttributeError` and still fail here, now with a message naming the layer, the tensor and the fact that config and checkpoint disagree. A blanket skip is not hypothetical harm: an earlier revision of this change did skip broadly and hid a `packed_modules_mapping` propagation bug (now [afierka-intel#12](https://github.com/afierka-intel/vllm/pull/12)) by quietly discarding weights instead of reporting them.

## Test plan

New file `tests/model_executor/layers/test_linear_load_weights.py` (7 cases). Each test asserts its own premise, so a test whose premise decays fails instead of passing for the wrong reason.

```bash
python3 -m pytest tests/model_executor/layers/test_linear_load_weights.py -q
```

Run against pristine `main` and against this branch. Baseline files were restored from the CI image rather than by reverse-applying a patch, and every file swap was followed by a `sha256sum` plus an in-process assertion of the loaded allowlist, so no result is attributed to a tree that was not actually in place:

| platform | pristine `main` | this PR |
|---|---|---|
| H200 NVL (sm90) | **5 failed**, 2 passed | **7 passed** |
| B200 (sm100) | **5 failed**, 2 passed | **7 passed** |
| Intel Arc Pro B-series (XPU) | **5 failed**, 2 passed | **7 passed** |

The 5 failures on `main` are the four "unregistered tensor must be diagnosable" cases (`g_idx` on both layer classes, `qweight`, and the message-content check) plus the `sub.bias` case; on `main` they die with `'MergedColumnParallelLinear' object has no attribute 'data'`, `'QKVParallelLinear' object has no attribute 'data'` and `'NoneType' object has no attribute 'weight_loader'`. The 2 that pass on both sides pin pre-existing behaviour (bare `bias` skip, matched-weight load) and are labelled as such in the file — they are not evidence for this change.

`linear.py` contains no platform checks, but it sits on every model's weight-loading path, so all three platforms were measured rather than argued from one.

### Real checkpoint

The GPTQ load above is also the proof that the changed line is actually executed on a real load (600 resolutions) rather than only in unit tests. Same script without the spy, greedy decoding, 3 prompts, `seed=42` — output is byte-identical between pristine `main` and this PR on both H200 and B200:

```
OUT: '______.\nA. London\nB. Berlin\nC. Madrid\nD'
OUT: ' 4\n2 * 2 = 4\n2 / 2 ='
OUT: ' there was a little girl who loved to read. She read every day, and'
```

### Accuracy

`lm_eval --model vllm --tasks gsm8k --limit 200 --batch_size 16 --seed 42` (5-shot), same checkpoint, H200:

| build | flexible-extract | strict-match |
|---|---|---|
| pristine `main` | 0.450 ± 0.0353 | 0.365 ± 0.0341 |
| this PR, run 1 | 0.445 ± 0.0352 | 0.355 ± 0.0339 |
| this PR, run 2 | 0.440 ± 0.0352 | 0.365 ± 0.0341 |

Two runs of the *same* build differ by 0.005 / 0.010, i.e. the run-to-run noise floor is as large as the `main`-to-PR delta, and every value sits well inside one stderr. That is the honest reading: no measurable accuracy change. Mechanically none is possible either — on a successful load the helper takes the same decisions as `main` (param found → same `weight_loader` call; `bias`-as-None → skip), which the spy counters confirm.

### Performance

Not benchmarked, and I claim no perf effect: the change is one `getattr` plus a set membership test per checkpoint tensor, executed during weight loading only, never in the forward path.

### Known evidence gap

The real-checkpoint spy and the accuracy run were done on CUDA only. On the XPU box the container has no HF cache mounted and the card had ~6 GB free, and the GPTQ-MoE load path there additionally depends on [afierka-intel#12](https://github.com/afierka-intel/vllm/pull/12), which would confound the result. To close it: an XPU container from `vllm-release-repo:<commit>-xpu` with `-v ~/.cache/huggingface:/root/.cache/huggingface`, #12 applied, then the same in-process spy and `lm_eval` invocations on `Qwen/Qwen1.5-MoE-A2.7B-Chat-GPTQ-Int4`. The XPU-side facts that *are* measured: the 7 unit tests (5→7 delta) and the per-platform `g_idx` registration probe above.

`ruff check` + `ruff format --check` clean (ruff 0.14.0, as pinned in `.pre-commit-config.yaml`); full `pre-commit run --files` on both changed files green, including mypy.

## Why this is not duplicating an existing PR

`gh pr list --repo vllm-project/vllm --state open --search ...` for `MergedColumnParallelLinear load_weights`, `_resolve_loadable_param`, `getattr(self, name, self)`, `optional checkpoint tensors`, `skip unregistered checkpoint tensor`. No open PR touches `MergedColumnParallelLinear.load_weights` / `QKVParallelLinear.load_weights`.

The nearest neighbour is [#43892](https://github.com/vllm-project/vllm/pull/43892) (`[Bugfix][DeepSeekV4] Handle optional scale tensors for W4A16-FP8 artifacts`), which fixes the same *class* of failure — a checkpoint tensor with no materialized param, including the identical `AttributeError: 'ColumnParallelLinear' object has no attribute ...` signature — but does so inside `vllm/models/deepseek_v4/`, with no file overlap with this PR. It skips a model-specific set of optional scale names; this PR deliberately does not generalize that skip into shared code, for the reason given above. [#41170](https://github.com/vllm-project/vllm/pull/41170) touches `WEIGHT_LOADER_V2_SUPPORTED` in the same file but not this code path.

## Relationship to other PRs

Split out of [afierka-intel#12](https://github.com/afierka-intel/vllm/pull/12) on review feedback: that PR is the minimal GPTQ-MoE loading fix (XPU allowlist + `packed_modules_mapping` propagation), while this one touches every model's load path and deserves its own review. **This PR is not required for that model to load** — with #12 applied the checkpoint loads and generates correctly without this change. Supersedes afierka-intel#9, a self-review staging PR for the same change.

Base is pinned to the commit the CI images above were built from, so every number here corresponds to exactly one tree.

---

AI assistance was used (Claude Code); every changed line was reviewed and all commands above were run personally on real hardware.
