### PR TITLE
[Bugfix] Allow grouped weight-only int8 MoE under moe_wna16 (alternative a of 2)

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -82,7 +82,6 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
             else:
                 scale = kInt4StaticGroupScale
         elif self.num_bits == 8:
-            assert self.group_size == -1
             scale = kInt8StaticGroupScale
         else:
             raise ValueError(

--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -222,7 +222,6 @@ class MoeWNA16Method(FusedMoEMethodBase):
             else:
                 scale = kInt4StaticGroupScale
         elif num_bits == 8:
-            assert group_size == -1
             quant_type = INT8_DTYPE
             scale = kInt8StaticGroupScale
         else:
@@ -253,6 +252,14 @@ class MoeWNA16Method(FusedMoEMethodBase):
         bit8_pack_factor = self.quant_config.bit8_pack_factor
         group_size = self.quant_config.group_size
         group_size_div_factor = 1
+
+        # group_size == -1 means per-channel: one scale per output row, i.e. a
+        # single group spanning the whole reduction axis. The loop below cannot
+        # normalise it (x % -1 == 0 for every x, so it exits immediately and
+        # leaves a negative divisor for the scale shapes), so map it to the
+        # axis length up front.
+        if group_size == -1:
+            group_size = min(intermediate_size_per_partition, hidden_size)
 
         # make intermediate_size and hidden_size divisible by group_size
         # we reduce the group size to ensure that


### PR DESCRIPTION
> ## ⚠️ Alternative (a) of 2 — do not merge both
>
> This PR and its sibling are **two opposite answers to one question**: should grouped weight-only int8 MoE work on the `moe_wna16` / compressed-tensors paths?
>
> - **(a) — this PR:** make it work, consistent with Marlin.
> - **(b) — the sibling:** keep it unsupported, but fail cleanly instead of asserting.
>
> Opened as drafts so the implementation is ready once a maintainer picks a direction. Whichever is chosen, the other gets closed.

## The problem

Grouped int8 (`W8A16`) MoE is rejected by two of the three code paths that accept the same checkpoints:

| path | grouped int8 MoE |
|---|---|
| `AutoGPTQMoEMethod` → Marlin | ✅ **works today** (`auto_gptq.py:480-482` builds `kInt8StaticGroupScale` with no `group_size` restriction) |
| `MoeWNA16Method` | ❌ broken at **every** `group_size` |
| `CompressedTensorsWNA16MoEMethod` | ❌ assert compares against `-1`, but the field is `128` or `None` |

"Broken at every `group_size`" is literal: `> 0` trips `assert group_size == -1`, and `-1` passes the assert then crashes in allocation.

## What this PR changes

1. **Drop the assert** in `MoeWNA16Method.__init__` and `CompressedTensorsWNA16MoEMethod.__init__`.
2. **Normalise `group_size == -1`** (per-channel) to the reduction-axis length in `create_weights`. Removing the assert alone is not enough: the existing normalisation loop cannot handle `-1`, because its condition is `intermediate_size % group_size or hidden_size % group_size` and `x % -1 == 0` for every `x` — so it exits immediately and leaves `-1` as the divisor, and `torch.zeros(..., hidden_size // -1, ...)` raises `RuntimeError: zeros: Dimension size must be non-negative`.

This restores the direction [#47154](https://github.com/vllm-project/vllm/pull/47154) already chose for Marlin ("allow int8 grouped WNA16 MoE on Marlin") before [#44570](https://github.com/vllm-project/vllm/pull/44570) reintroduced the assert by consolidating that class into the shared one.

## Test plan

Verified on **B200 (sm100)** and **Intel B70 (XPU)** — identical results on both:

| config | before | after |
|---|---|---|
| int8, `group_size=128` | `AssertionError` | method OK, `create_weights` OK, `group_size=128` |
| int8, `group_size=-1` | `RuntimeError` negative dim | method OK, `create_weights` OK, `group_size=512` |
| int4, `group_size=128` | OK | OK (unchanged) |

Existing suites unaffected: `test_int8_moe_oracle.py`, `test_linear_load_weights.py` and `test_fused_moe_kernel_gptq_awq.py` all pass on B70, H200 and B200 with this applied.

`ruff check` + `ruff format --check` clean (ruff 0.14.0).

## What is missing, stated plainly

**No end-to-end validation.** I have no grouped-int8 MoE checkpoint served through a model, so the evidence here is construction-level: the layer builds and the weights allocate with correct shapes. Real checkpoints exist — [`QuantTrio/Qwen3-Coder-30B-A3B-Instruct-GPTQ-Int8`](https://huggingface.co/QuantTrio/Qwen3-Coder-30B-A3B-Instruct-GPTQ-Int8), [`88plug/Qwen3.6-35B-A3B-W8A16`](https://huggingface.co/88plug/Qwen3.6-35B-A3B-W8A16) — and `llm-compressor`'s `W8A16` preset emits `group_size=128` by default, so an accuracy eval on one of those is the natural gate before merge. I did not verify whether `fused_moe_kernel_gptq_awq`, which takes `group_size` as a `constexpr` and indexes scales by it, is correct for the normalised per-channel value; that also needs the eval.

---

AI assistance was used (Claude Code); every changed line was reviewed and all tests above were run personally on NVIDIA B200 and Intel B70 hardware.
