### PR TITLE
[Bugfix] Reject grouped int8 MoE cleanly under moe_wna16 (alternative b of 2)

### DIFF
--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -159,7 +159,16 @@ class MoeWNA16Config(QuantizationConfig):
 
         awq_min_capability = AutoAWQConfig.get_min_capability()
 
-        gptq_compatible = quant_method == "gptq" and not desc_act and num_bits in [4, 8]
+        # MoeWNA16Method only supports per-channel int8 (see the group_size
+        # assert in MoeWNA16Method.__init__), so do not claim a grouped 8-bit
+        # checkpoint is convertible -- otherwise the failure surfaces as an
+        # assert deep in layer construction instead of a config error.
+        group_size = quant_config.get("group_size")
+        gptq_compatible = (
+            quant_method == "gptq"
+            and not desc_act
+            and (num_bits == 4 or (num_bits == 8 and group_size in (-1, None)))
+        )
         awq_compatible = (
             quant_method == "awq"
             and num_bits == 4
@@ -222,7 +231,12 @@ class MoeWNA16Method(FusedMoEMethodBase):
             else:
                 scale = kInt4StaticGroupScale
         elif num_bits == 8:
-            assert group_size == -1
+            if group_size != -1:
+                raise ValueError(
+                    "moe_wna16 supports int8 MoE weights only with "
+                    f"group_size=-1 (per-channel), got {group_size}. Use "
+                    "--quantization gptq_marlin for grouped int8 MoE."
+                )
             quant_type = INT8_DTYPE
             scale = kInt8StaticGroupScale
         else:


### PR DESCRIPTION
> ## ⚠️ Alternative (b) of 2 — do not merge both
>
> This PR and [#18](https://github.com/afierka-intel/vllm/pull/18) are **two opposite answers to one question**: should grouped weight-only int8 MoE work on the `moe_wna16` path?
>
> - **(a) — [#18](https://github.com/afierka-intel/vllm/pull/18):** make it work, consistent with Marlin.
> - **(b) — this PR:** keep it unsupported, but fail honestly instead of asserting.
>
> Opened as drafts so the implementation is ready once a maintainer picks a direction. Whichever is chosen, the other gets closed.

## The problem

`MoeWNA16Method` supports int8 MoE only per-channel, but two things hid that from users:

1. `is_moe_wna16_compatible` accepted `num_bits in [4, 8]` with **no `group_size` check** (`moe_wna16.py:168`), so `--quantization moe_wna16` reported a grouped GPTQ-Int8 checkpoint as convertible.
2. The restriction was then enforced by a bare `assert group_size == -1` inside `MoeWNA16Method.__init__` — an `AssertionError` with no message, raised deep in layer construction, after the config layer already said "yes".

## What this PR changes

- `is_moe_wna16_compatible` now accepts 8-bit only for `group_size in (-1, None)`, so a grouped int8 checkpoint is not claimed as convertible in the first place.
- The bare assert becomes a `ValueError` naming the constraint and pointing at `gptq_marlin`, which does handle grouped int8 MoE today.

Deliberately **not** addressed here: `group_size == -1` — the one value this path permits — still fails later in `create_weights`, because `hidden_size // -1` is negative (`RuntimeError: zeros: Dimension size must be non-negative`). Fixing that is part of alternative (a). This PR only makes the *documented* restriction honest; it does not claim per-channel int8 works.

## Test plan

Verified on **B200 (sm100)**:

| check | before | after |
|---|---|---|
| `is_moe_wna16_compatible(bits=8, gs=128)` | `True`, then asserts later | **`False`** |
| `is_moe_wna16_compatible(bits=8, gs=-1)` | `True` | `True` |
| `is_moe_wna16_compatible(bits=4, gs=128)` | `True` | `True` |
| build with `bits=8, gs=128` | bare `AssertionError` | `ValueError` naming the constraint |

`ruff check` + `ruff format --check` clean (ruff 0.14.0). No perf or accuracy impact — both changed sites run once at config/layer construction, never on a forward path.

## Trade-off, stated plainly

This leaves grouped int8 MoE unsupported on the `moe_wna16` path even though real checkpoints exist ([`QuantTrio/Qwen3-Coder-30B-A3B-Instruct-GPTQ-Int8`](https://huggingface.co/QuantTrio/Qwen3-Coder-30B-A3B-Instruct-GPTQ-Int8), [`88plug/Qwen3.6-35B-A3B-W8A16`](https://huggingface.co/88plug/Qwen3.6-35B-A3B-W8A16)), and `llm-compressor`'s `W8A16` preset emits `group_size=128` by default — so users following the documented quantization path hit this. They would need `--quantization gptq_marlin` instead.

If that is not the intended semantics, take [#18](https://github.com/afierka-intel/vllm/pull/18) instead. I have no preference to defend here beyond wanting the three paths to agree; [#47154](https://github.com/vllm-project/vllm/pull/47154) suggests (a) matches the earlier intent.

---

AI assistance was used (Claude Code); every changed line was reviewed and all tests above were run personally on NVIDIA B200 hardware.
