### PR TITLE
[Bugfix] Allow grouped weight-only int8 MoE under moe_wna16

### DIFF
--- a/tests/quantization/test_moe_wna16.py
+++ b/tests/quantization/test_moe_wna16.py
@@ -203,3 +203,46 @@ def test_moe_wna16_uses_humming_quant_config(monkeypatch):
     )
 
     assert method.get_fused_moe_quant_config(layer) is quant_config
+
+
+@pytest.mark.parametrize("hidden,intermediate", [(2048, 768), (2048, 512)])
+def test_moe_wna16_grouped_int8_scale_group_counts(hidden, intermediate):
+    """Grouped int8 must allocate one scale group per group_size along each
+    reduction axis, independently for w13 (K=hidden) and w2 (K=intermediate).
+
+    Shapes use hidden != intermediate so a single shared divisor cannot satisfy
+    both, which is what makes the assertion meaningful.
+    """
+    group_size = 128
+    quant_config = MoeWNA16Config(
+        linear_quant_method="gptq",
+        weight_bits=8,
+        group_size=group_size,
+        has_zp=False,
+        lm_head_quantized=False,
+        modules_to_not_convert=None,
+        full_config={},
+    )
+    from tests.kernels.moe.utils import make_dummy_moe_config
+
+    # On XPU the WNA16 priority list is [XPU] alone and XPUExpertsWNA16 accepts
+    # int4 only, so request TRITON explicitly to keep this test device-neutral.
+    moe_config = make_dummy_moe_config(
+        num_experts=8, hidden_dim=hidden, intermediate_size=intermediate
+    )
+    moe_config.moe_backend = "triton"
+    method = moe_wna16.MoeWNA16Method(quant_config, moe_config)
+
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        8,
+        hidden,
+        intermediate,
+        torch.bfloat16,
+        weight_loader=lambda *a, **k: None,
+    )
+
+    assert layer.group_size == group_size
+    assert layer.w13_scales.shape[-1] == hidden // group_size
+    assert layer.w2_scales.shape[-1] == intermediate // group_size

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -82,7 +82,6 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
             else:
                 scale = kInt4StaticGroupScale
         elif self.num_bits == 8:
-            assert self.group_size == -1
             scale = kInt8StaticGroupScale
         else:
             raise ValueError(

--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -222,7 +222,6 @@ class MoeWNA16Method(FusedMoEMethodBase):
             else:
                 scale = kInt4StaticGroupScale
         elif num_bits == 8:
-            assert group_size == -1
             quant_type = INT8_DTYPE
             scale = kInt8StaticGroupScale
         else:


### PR DESCRIPTION
## Summary

`MoeWNA16Method.__init__` (`moe_wna16.py:225`) and `CompressedTensorsWNA16MoEMethod.__init__` (`compressed_tensors_moe_wna16.py:85`) assert `group_size == -1` for 8-bit weights, so every grouped int8 MoE checkpoint is rejected before a backend is selected. `AutoGPTQMoEMethod` carries no such restriction, so the same checkpoint loads through one path and not the other two.

[#47154](https://github.com/vllm-project/vllm/pull/47154) (`c8d2f3cb14`) removed this assert from `CompressedTensorsWNA16MarlinMoEMethod` — titled "allow int8 grouped WNA16 MoE on Marlin". [#44570](https://github.com/vllm-project/vllm/pull/44570) (`454ea5b526`) then merged that class into `CompressedTensorsWNA16MoEMethod` and re-added the assert as refactor collateral. #47154 precedes #44570, so this restores a decision that was already taken.

## Why nothing else is needed

`create_weights`'s existing normalisation loop already produces the correct group counts, independently per axis — `w13_scales` divides `hidden_size`, `w2_scales` divides `intermediate_size_per_partition`. Verified:

| hidden | intermediate | group_size | w13 groups | w2 groups |
|---|---|---|---|---|
| 2048 | 768 | 128 | 16 | 6 |
| 2048 | 512 | 128 | 16 | 4 |

The kernel's scale indexing (`k // group_size`, `fused_moe.py`) is likewise already correct for a positive group size. This PR is two deleted lines.

**Per-channel int8 (`group_size == -1`) is deliberately out of scope.** It needs `num_groups = 1` on both axes plus `FusedMoeWeightScaleSupported.CHANNEL` and is a separate change — see the companion PR.

## Test plan

`test_moe_wna16_grouped_int8_scale_group_counts` pins the per-axis group counts. Shapes use `hidden != intermediate` deliberately: a single shared divisor cannot satisfy both, so the assertion would catch a substituted `group_size` rather than merely confirming that allocation did not raise.

| | Intel B70 (XPU) |
|---|---|
| unpatched | **`AssertionError`** at `moe_wna16.py:225` |
| with this change | **2 passed** |

The test requests `moe_backend="triton"` explicitly: on XPU the WNA16 priority list is `[XPU]` alone (`oracle/int_wna16.py:114-115`) and `XPUExpertsWNA16` accepts int4 keys only (`experts/xpu_moe.py:294-302`), so without the override the oracle raises before reaching the code under test.

`ruff check` + `ruff format --check` clean (ruff 0.14.0).

## What is missing

**No end-to-end validation.** I have no grouped-int8 MoE checkpoint served through a model, so the evidence is construction-level: the layer builds and the scale shapes are right per axis. Real checkpoints exist — [`QuantTrio/Qwen3-Coder-30B-A3B-Instruct-GPTQ-Int8`](https://huggingface.co/QuantTrio/Qwen3-Coder-30B-A3B-Instruct-GPTQ-Int8), [`88plug/Qwen3.6-35B-A3B-W8A16`](https://huggingface.co/88plug/Qwen3.6-35B-A3B-W8A16) — and `llm-compressor`'s `W8A16` preset emits `group_size=128` by default, so an accuracy eval on one of those is the natural gate before merge. Note that eval must run through `TRITON` or `MARLIN`; the XPU backend never reaches this kernel.

---

AI assistance was used (Claude Code); every changed line was reviewed and the tests above were run personally on Intel B70 hardware.
