### PR TITLE
[Bugfix] Support per-channel weight-only int8 MoE under moe_wna16

### DIFF
--- a/tests/quantization/test_moe_wna16.py
+++ b/tests/quantization/test_moe_wna16.py
@@ -203,3 +203,85 @@ def test_moe_wna16_uses_humming_quant_config(monkeypatch):
     )
 
     assert method.get_fused_moe_quant_config(layer) is quant_config
+
+
+@pytest.mark.parametrize("hidden,intermediate", [(2048, 768), (2048, 512)])
+def test_moe_wna16_grouped_int8_scale_group_counts(hidden, intermediate):
+    """Grouped int8 must allocate one scale group per group_size along each
+    reduction axis, independently for w13 (K=hidden) and w2 (K=intermediate).
+
+    Shapes use hidden != intermediate so a single shared divisor cannot satisfy
+    both, which is what makes the assertion meaningful.
+    """
+    group_size = 128
+    quant_config = MoeWNA16Config(
+        linear_quant_method="gptq",
+        weight_bits=8,
+        group_size=group_size,
+        has_zp=False,
+        lm_head_quantized=False,
+        modules_to_not_convert=None,
+        full_config={},
+    )
+    from tests.kernels.moe.utils import make_dummy_moe_config
+
+    # On XPU the WNA16 priority list is [XPU] alone and XPUExpertsWNA16 accepts
+    # int4 only, so request TRITON explicitly to keep this test device-neutral.
+    moe_config = make_dummy_moe_config(
+        num_experts=8, hidden_dim=hidden, intermediate_size=intermediate
+    )
+    moe_config.moe_backend = "triton"
+    method = moe_wna16.MoeWNA16Method(quant_config, moe_config)
+
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        8,
+        hidden,
+        intermediate,
+        torch.bfloat16,
+        weight_loader=lambda *a, **k: None,
+    )
+
+    assert layer.group_size == group_size
+    assert layer.w13_scales.shape[-1] == hidden // group_size
+    assert layer.w2_scales.shape[-1] == intermediate // group_size
+
+
+@pytest.mark.parametrize("hidden,intermediate", [(2048, 768), (2048, 512)])
+def test_moe_wna16_per_channel_int8_uses_one_group_per_axis(hidden, intermediate):
+    """Per-channel int8 (group_size=-1) needs exactly one scale group on each
+    reduction axis, independently for w13 and w2.
+
+    A single shared divisor cannot express that when hidden != intermediate, so
+    these shapes would expose a substituted group_size.
+    """
+    from tests.kernels.moe.utils import make_dummy_moe_config
+
+    quant_config = MoeWNA16Config(
+        linear_quant_method="gptq",
+        weight_bits=8,
+        group_size=-1,
+        has_zp=False,
+        lm_head_quantized=False,
+        modules_to_not_convert=None,
+        full_config={},
+    )
+    moe_config = make_dummy_moe_config(
+        num_experts=8, hidden_dim=hidden, intermediate_size=intermediate
+    )
+    moe_config.moe_backend = "triton"
+    method = moe_wna16.MoeWNA16Method(quant_config, moe_config)
+
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        8,
+        hidden,
+        intermediate,
+        torch.bfloat16,
+        weight_loader=lambda *a, **k: None,
+    )
+
+    assert layer.w13_scales.shape[-1] == 1
+    assert layer.w2_scales.shape[-1] == 1

--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -222,7 +222,6 @@ class MoeWNA16Method(FusedMoEMethodBase):
             else:
                 scale = kInt4StaticGroupScale
         elif num_bits == 8:
-            assert group_size == -1
             quant_type = INT8_DTYPE
             scale = kInt8StaticGroupScale
         else:
@@ -254,17 +253,30 @@ class MoeWNA16Method(FusedMoEMethodBase):
         group_size = self.quant_config.group_size
         group_size_div_factor = 1
 
-        # make intermediate_size and hidden_size divisible by group_size
-        # we reduce the group size to ensure that
-        # and we would repeat the loaded_weight later
-        while intermediate_size_per_partition % group_size or hidden_size % group_size:
-            group_size = group_size // 2
-            group_size_div_factor *= 2
-            assert group_size >= 32
+        # group_size == -1 is per-channel: one scale per output row, i.e. a
+        # single group on each reduction axis independently. The loop below
+        # cannot express that (it shares one divisor between the two axes, and
+        # x % -1 == 0 makes it exit immediately), so handle it separately, as
+        # AutoGPTQMoEMethod and CompressedTensorsWNA16MoEMethod already do.
+        per_channel = group_size == -1
+        if per_channel:
+            num_groups_w13 = num_groups_w2 = 1
+            strategy = FusedMoeWeightScaleSupported.CHANNEL.value
+        else:
+            # make intermediate_size and hidden_size divisible by group_size
+            # we reduce the group size to ensure that
+            # and we would repeat the loaded_weight later
+            while (
+                intermediate_size_per_partition % group_size or hidden_size % group_size
+            ):
+                group_size = group_size // 2
+                group_size_div_factor *= 2
+                assert group_size >= 32
+            num_groups_w13 = hidden_size // group_size
+            num_groups_w2 = intermediate_size_per_partition // group_size
+            strategy = FusedMoeWeightScaleSupported.GROUP.value
         layer.group_size = group_size
         layer.group_size_div_factor = group_size_div_factor
-
-        strategy = FusedMoeWeightScaleSupported.GROUP.value
         extra_weight_attrs.update({"quant_method": strategy, "is_transposed": False})
 
         assert "weight_loader" in extra_weight_attrs
@@ -302,7 +314,7 @@ class MoeWNA16Method(FusedMoEMethodBase):
             torch.zeros(
                 num_experts,
                 self.moe.w13_num_shards * intermediate_size_per_partition,
-                hidden_size // group_size,
+                num_groups_w13,
                 dtype=params_dtype,
             ),
             requires_grad=False,
@@ -314,7 +326,7 @@ class MoeWNA16Method(FusedMoEMethodBase):
             torch.zeros(
                 num_experts,
                 hidden_size,
-                intermediate_size_per_partition // group_size,
+                num_groups_w2,
                 dtype=params_dtype,
             ),
             requires_grad=False,
@@ -329,7 +341,7 @@ class MoeWNA16Method(FusedMoEMethodBase):
                     self.moe.w13_num_shards
                     * intermediate_size_per_partition
                     // bit8_pack_factor,
-                    hidden_size // group_size,
+                    num_groups_w13,
                     dtype=torch.uint8,
                 ),
                 requires_grad=False,
@@ -341,7 +353,7 @@ class MoeWNA16Method(FusedMoEMethodBase):
                 torch.zeros(
                     num_experts,
                     hidden_size // bit8_pack_factor,
-                    intermediate_size_per_partition // group_size,
+                    num_groups_w2,
                     dtype=torch.uint8,
                 ),
                 requires_grad=False,


### PR DESCRIPTION
## Summary

`group_size == -1` means per-channel: one scale per output row, i.e. a single group on each reduction axis. `MoeWNA16Method.create_weights` cannot express that, and int8 consequently fails at *every* group size:

- `group_size > 0` → `assert group_size == -1` in `__init__` (`moe_wna16.py:225`)
- `group_size == -1` → passes the assert, then `hidden_size // -1` is negative and `torch.zeros` raises `RuntimeError: zeros: Dimension size must be non-negative` (`:305`, `:317`)

## Why substituting a value for `-1` does not work

The obvious fix — replace `-1` with some concrete divisor — is wrong, and quietly so. The normalisation loop shares **one** divisor between **two** axes: `w13_scales` divides `hidden_size`, `w2_scales` divides `intermediate_size_per_partition`. For hidden=2048, intermediate=512, substituting 512 gives:

| tensor | groups | per-channel needs |
|---|---|---|
| `w13_scales` | **4** | 1 |
| `w2_scales` | 1 | 1 |

The loop cannot correct this (`2048 % 512 == 0`), and the load path narrows the group dimension rather than failing — so the surplus groups stay zero and the kernel scales part of the reduction axis by 0. Silent wrong numerics, not a crash.

This PR therefore handles per-channel explicitly, with `num_groups = 1` on both axes and `FusedMoeWeightScaleSupported.CHANNEL`, mirroring the two existing in-tree implementations: `auto_gptq.py:530-533` and `compressed_tensors_moe_wna16.py:294-296`. Scale and zero-point allocations now use per-axis group counts instead of dividing by `group_size`.

## Test plan

Two tests, both parametrized over `hidden != intermediate` so a substituted divisor cannot pass:

- `test_moe_wna16_per_channel_int8_uses_one_group_per_axis` — asserts one group on each axis
- `test_moe_wna16_grouped_int8_scale_group_counts` — pins that positive group sizes still get their per-axis counts (16/6 and 16/4), i.e. this change does not regress the grouped path

| | Intel B70 (XPU) |
|---|---|
| unpatched | **4 failed** |
| with this change | **4 passed** |

Both tests request `moe_backend="triton"`: on XPU the WNA16 priority list is `[XPU]` alone and `XPUExpertsWNA16` accepts int4 keys only, so the oracle would otherwise raise before reaching the code under test.

`ruff check` + `ruff format --check` clean (ruff 0.14.0).

## Relationship to other PRs

Stacks conceptually on the grouped-int8 fix (companion PR), which removes the same two asserts for the `group_size > 0` case. This PR is self-contained — it also drops the `moe_wna16` assert — but the two are cleaner reviewed in order: grouped first, then per-channel.

## What is missing

**No end-to-end validation.** No per-channel int8 MoE checkpoint served through a model; the evidence is construction-level (correct per-axis scale shapes). An accuracy eval is the natural gate before merge, and it must run through `TRITON` or `MARLIN` — the XPU backend never reaches this kernel.

---

AI assistance was used (Claude Code); every changed line was reviewed and the tests above were run personally on Intel B70 hardware.
