### PR TITLE
[XPU][TD] chunk_gated_delta_rule_fwd_kernel_h_blockdim64: tensor-descriptor path

### DIFF
--- a/vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py
@@ -10,7 +10,8 @@
 
 import torch
 
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import tl, triton, use_tensor_descriptor
+from vllm.triton_utils.allocation import set_triton_allocator
 
 from .index import prepare_chunk_indices, prepare_chunk_offsets
 from .op import exp, exp2
@@ -19,6 +20,8 @@ from .utils import FLA_CHUNK_SIZE, use_cuda_graph
 NUM_WARPS = [2, 4, 8, 16]
 # Triton's AMD backend fails to lower this kernel with num_stages=4.
 _CHUNK_DELTA_H_NUM_STAGES = [2, 3] if torch.version.hip else [2, 3, 4]
+
+_TD_ALLOCATOR_DEVICES: set[torch.device] = set()
 
 
 @triton.heuristics(
@@ -68,6 +71,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     SAVE_NEW_VALUE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_EXP2: tl.constexpr,
+    USE_TD: tl.constexpr = False,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
@@ -109,6 +113,29 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     if STORE_FINAL_STATE:
         ht = ht + i_nh * V * K
 
+    if USE_TD:
+        # k is [T, K]-major from this head's base; the (K, T) tile the non-TD
+        # path loads is obtained by transposing a [BT, 64] descriptor tile.
+        k_desc = tl.make_tensor_descriptor(
+            k, shape=[T, K], strides=[stride_k, 1], block_shape=[BT, 64]
+        )
+        v_desc = tl.make_tensor_descriptor(
+            v, shape=[T, V], strides=[stride_v, 1], block_shape=[BT, BV]
+        )
+        w_desc = tl.make_tensor_descriptor(
+            w, shape=[T, K], strides=[stride_w, 1], block_shape=[BT, 64]
+        )
+        # h is contiguous, so the chunk-major region is a flat row matrix with
+        # row stride K; row (i_t, i) lives at i_t * H * V + i. The host gates
+        # this on V % BV == 0 so a tile never crosses into the next head.
+        h_desc = tl.make_tensor_descriptor(
+            h, shape=[NT * H * V, K], strides=[K, 1], block_shape=[BV, 64]
+        )
+        if SAVE_NEW_VALUE:
+            vn_desc = tl.make_tensor_descriptor(
+                v_new, shape=[T, V], strides=[stride_v, 1], block_shape=[BT, BV]
+            )
+
     # load initial state
     if USE_INITIAL_STATE:
         p_h0_1 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
@@ -131,79 +158,107 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
     # main recurrence
     for i_t in range(NT):
-        p_h1 = tl.make_block_ptr(
-            h + i_t.to(tl.int64) * stride_h,
-            (V, K),
-            (K, 1),
-            (i_v * BV, 0),
-            (BV, 64),
-            (1, 0),
-        )
-        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
-        if K > 64:
-            p_h2 = tl.make_block_ptr(
+        if USE_TD:
+            o_h = i_t * (H * V) + i_v * BV
+            h_desc.store([o_h, 0], b_h1.to(h.dtype.element_ty))
+            if K > 64:
+                h_desc.store([o_h, 64], b_h2.to(h.dtype.element_ty))
+            if K > 128:
+                h_desc.store([o_h, 128], b_h3.to(h.dtype.element_ty))
+            if K > 192:
+                h_desc.store([o_h, 192], b_h4.to(h.dtype.element_ty))
+        else:
+            p_h1 = tl.make_block_ptr(
                 h + i_t.to(tl.int64) * stride_h,
                 (V, K),
                 (K, 1),
-                (i_v * BV, 64),
+                (i_v * BV, 0),
                 (BV, 64),
                 (1, 0),
             )
-            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
-        if K > 128:
-            p_h3 = tl.make_block_ptr(
-                h + i_t.to(tl.int64) * stride_h,
-                (V, K),
-                (K, 1),
-                (i_v * BV, 128),
-                (BV, 64),
-                (1, 0),
-            )
-            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
-        if K > 192:
-            p_h4 = tl.make_block_ptr(
-                h + i_t.to(tl.int64) * stride_h,
-                (V, K),
-                (K, 1),
-                (i_v * BV, 192),
-                (BV, 64),
-                (1, 0),
-            )
-            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+            if K > 64:
+                p_h2 = tl.make_block_ptr(
+                    h + i_t.to(tl.int64) * stride_h,
+                    (V, K),
+                    (K, 1),
+                    (i_v * BV, 64),
+                    (BV, 64),
+                    (1, 0),
+                )
+                tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
+            if K > 128:
+                p_h3 = tl.make_block_ptr(
+                    h + i_t.to(tl.int64) * stride_h,
+                    (V, K),
+                    (K, 1),
+                    (i_v * BV, 128),
+                    (BV, 64),
+                    (1, 0),
+                )
+                tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
+            if K > 192:
+                p_h4 = tl.make_block_ptr(
+                    h + i_t.to(tl.int64) * stride_h,
+                    (V, K),
+                    (K, 1),
+                    (i_v * BV, 192),
+                    (BV, 64),
+                    (1, 0),
+                )
+                tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
 
-        p_w = tl.make_block_ptr(
-            w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
-        )
-        b_w = tl.load(p_w, boundary_check=(0, 1))
+        if USE_TD:
+            b_w = w_desc.load([i_t * BT, 0])
+        else:
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+            )
+            b_w = tl.load(p_w, boundary_check=(0, 1))
         b_v = tl.dot(b_w, tl.trans(b_h1).to(b_w.dtype))
         if K > 64:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            if USE_TD:
+                b_w = w_desc.load([i_t * BT, 64])
+            else:
+                p_w = tl.make_block_ptr(
+                    w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
+                )
+                b_w = tl.load(p_w, boundary_check=(0, 1))
             b_v += tl.dot(b_w, tl.trans(b_h2).to(b_w.dtype))
         if K > 128:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            if USE_TD:
+                b_w = w_desc.load([i_t * BT, 128])
+            else:
+                p_w = tl.make_block_ptr(
+                    w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
+                )
+                b_w = tl.load(p_w, boundary_check=(0, 1))
             b_v += tl.dot(b_w, tl.trans(b_h3).to(b_w.dtype))
         if K > 192:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            if USE_TD:
+                b_w = w_desc.load([i_t * BT, 192])
+            else:
+                p_w = tl.make_block_ptr(
+                    w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
+                )
+                b_w = tl.load(p_w, boundary_check=(0, 1))
             b_v += tl.dot(b_w, tl.trans(b_h4).to(b_w.dtype))
-        p_v = tl.make_block_ptr(
-            v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-        )
-        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+        if USE_TD:
+            b_v = v_desc.load([i_t * BT, i_v * BV]) - b_v
+        else:
+            p_v = tl.make_block_ptr(
+                v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+            )
+            b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
 
         if SAVE_NEW_VALUE:
-            p_v = tl.make_block_ptr(
-                v_new, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-            )
-            tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
+            if USE_TD:
+                vn_desc.store([i_t * BT, i_v * BV], b_v.to(v_new.dtype.element_ty))
+            else:
+                p_v = tl.make_block_ptr(
+                    v_new, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+                )
+                tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
 
         last_idx = min((i_t.to(tl.int64) + 1) * BT, T) - 1
         if USE_G:
@@ -273,28 +328,40 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                     b_h4 *= exp(b_gk_last4)[None, :]
         b_v = b_v.to(k.dtype.element_ty)
 
-        p_k = tl.make_block_ptr(
-            k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
-        )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        if USE_TD:
+            b_k = tl.trans(k_desc.load([i_t * BT, 0]))
+        else:
+            p_k = tl.make_block_ptr(
+                k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
         b_h1 += tl.trans(tl.dot(b_k, b_v))
         if K > 64:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            if USE_TD:
+                b_k = tl.trans(k_desc.load([i_t * BT, 64]))
+            else:
+                p_k = tl.make_block_ptr(
+                    k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
+                )
+                b_k = tl.load(p_k, boundary_check=(0, 1))
             b_h2 += tl.trans(tl.dot(b_k, b_v))
         if K > 128:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            if USE_TD:
+                b_k = tl.trans(k_desc.load([i_t * BT, 128]))
+            else:
+                p_k = tl.make_block_ptr(
+                    k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
+                )
+                b_k = tl.load(p_k, boundary_check=(0, 1))
             b_h3 += tl.trans(tl.dot(b_k, b_v))
         if K > 192:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            if USE_TD:
+                b_k = tl.trans(k_desc.load([i_t * BT, 192]))
+            else:
+                p_k = tl.make_block_ptr(
+                    k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
+                )
+                b_k = tl.load(p_k, boundary_check=(0, 1))
             b_h4 += tl.trans(tl.dot(b_k, b_v))
     # epilogue
     if STORE_FINAL_STATE:
@@ -331,6 +398,7 @@ def chunk_gated_delta_rule_fwd_h(
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
     use_exp2: bool = False,
+    use_td: bool | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     # This kernel is slightly different from fla to support Q/K with different head numbers.
     # In fla, Q/K always have the same head number, so Hg is always equal to H.
@@ -359,6 +427,27 @@ def chunk_gated_delta_rule_fwd_h(
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), N * H)
 
+    # TD operand loads/stores for k, v, w, v_new and h. Gated on last-dim
+    # contiguity, power-of-two tiles and 16-byte alignment of every descriptor
+    # row stride. V % 64 == 0 keeps an h tile (BV in {32, 64}) inside one head.
+    e_k, e_u, e_w = k.element_size(), u.element_size(), w.element_size()
+    use_td = (
+        use_tensor_descriptor(use_td)
+        and k.is_contiguous()
+        and u.is_contiguous()
+        and w.is_contiguous()
+        and V % 64 == 0
+        and (BT & (BT - 1)) == 0
+        and (K * e_k) % 16 == 0
+        and (V * e_u) % 16 == 0
+        and (Hg * K * e_k) % 16 == 0
+        and (H * K * e_w) % 16 == 0
+        and (H * V * e_u) % 16 == 0
+    )
+    if use_td and k.device not in _TD_ALLOCATOR_DEVICES:
+        set_triton_allocator(k.device)
+        _TD_ALLOCATOR_DEVICES.add(k.device)
+
     chunk_gated_delta_rule_fwd_kernel_h_blockdim64[grid](
         k=k,
         v=u,
@@ -378,5 +467,6 @@ def chunk_gated_delta_rule_fwd_h(
         V=V,
         BT=BT,
         USE_EXP2=use_exp2,
+        USE_TD=use_td,
     )
     return h, v_new, final_state


### PR DESCRIPTION
## What

Adds an opt-in `USE_TD` tensor-descriptor load/store path to `chunk_gated_delta_rule_fwd_kernel_h_blockdim64`
in `vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py`, gated by `VLLM_TRITON_USE_TD` through
`vllm.triton_utils.use_tensor_descriptor()`. `USE_TD=False` keeps the
original pointer+mask path.

## Why

Evidence gathering for VLLMZ-1805 (TD enablement across vLLM Triton kernels).
This kernel was previously closed as *rejected* or *dropped*; we are
re-measuring every one of them on Intel Battlemage (B70) rather than relying on
the earlier verdicts, so the Triton Compiler team gets per-kernel numbers.

## Base

Branched from `afierka/td-base` (pinned at `5fd7a8883`) because the XPU
benchmark container is built from that commit — the mounted source tree has to
match the image's compiled extensions for the measurements to be valid.

## Testing

XPU only, TP=1. Kernel unit tests are run with `VLLM_TRITON_USE_TD=0` and
`=1`; E2E is `vllm bench sweep serve` on ShareGPT, 3 runs, median, seed 42,
prefix caching off. Results are attached to the campaign report, not here.

CUDA/ROCm correctness was **not** validated — this PR is a measurement vehicle
on the fork and is not proposed for upstream in this form.

AI assistance was used to produce this change.
