### PR TITLE
[XPU][TD] merge_attn_states_kernel: tensor-descriptor path

### DIFF
--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -4,9 +4,30 @@
 import torch
 
 from vllm.platforms import current_platform
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import tl, triton, use_tensor_descriptor
+from vllm.triton_utils.allocation import set_triton_allocator
 
 float8_info = torch.finfo(current_platform.fp8_dtype())
+
+_TD_ALLOCATOR_DEVICES: set[torch.device] = set()
+
+
+def _td_layout_ok(
+    t: torch.Tensor, head_size: int, head_stride: int, num_heads: int
+) -> bool:
+    # Tensor descriptors need a unit innermost stride, a 16-byte aligned base
+    # and leading stride, and the [tokens, heads] axes must collapse into a
+    # single row axis of stride ``head_stride`` (the layout the pointer path
+    # already assumes).
+    return (
+        t.dim() == 3
+        and t.stride(2) == 1
+        and t.stride(1) == head_stride
+        and t.stride(0) == num_heads * head_stride
+        and (head_size * t.element_size()) % 16 == 0
+        and (head_stride * t.element_size()) % 16 == 0
+        and t.data_ptr() % 16 == 0
+    )
 
 
 # Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
@@ -20,6 +41,7 @@ def merge_attn_states(
     output_lse: torch.Tensor | None = None,
     prefill_tokens_with_context: int | None = None,
     output_scale: torch.Tensor | None = None,
+    use_td: bool | None = None,
 ) -> None:
     num_tokens = output.shape[0]
     num_query_heads = output.shape[1]
@@ -44,6 +66,21 @@ def merge_attn_states(
     if prefill_tokens_with_context is None:
         prefill_tokens_with_context = num_tokens
 
+    # TD describes each output buffer as a 2D [tokens * heads, head_size] view
+    # and moves one row per program. Gated on a power-of-2 head_size because
+    # descriptor stores do not mask the padded tail, so block_shape must match
+    # the described extent exactly.
+    use_td = (
+        use_tensor_descriptor(use_td)
+        and head_size == padded_head_size
+        and _td_layout_ok(output, head_size, output_head_stride, num_query_heads)
+        and _td_layout_ok(prefix_output, head_size, prefix_head_stride, num_query_heads)
+        and _td_layout_ok(suffix_output, head_size, prefix_head_stride, num_query_heads)
+    )
+    if use_td and output.device not in _TD_ALLOCATOR_DEVICES:
+        set_triton_allocator(output.device)
+        _TD_ALLOCATOR_DEVICES.add(output.device)
+
     # TODO(woosuk): Use CUDA kernel instead of Triton to minimize CPU overhead.
     merge_attn_states_kernel[(num_tokens, num_query_heads)](
         output,
@@ -66,6 +103,7 @@ def merge_attn_states(
         padded_head_size,
         output_lse is not None,
         output_scale is not None,
+        USE_TD=use_td,
     )
 
 
@@ -93,6 +131,7 @@ def merge_attn_states_kernel(
     USE_FP8: tl.constexpr,
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
+    USE_TD: tl.constexpr = False,
 ):
     token_idx = tl.program_id(0)
     head_idx = tl.program_id(1)
@@ -102,6 +141,33 @@ def merge_attn_states_kernel(
 
     head_arange = tl.arange(0, PADDED_HEAD_SIZE)
     head_mask = head_arange < HEAD_SIZE
+
+    if USE_TD:
+        tl.static_assert(
+            HEAD_SIZE == PADDED_HEAD_SIZE,
+            "USE_TD requires a power-of-2 head_size: descriptor stores do "
+            "not mask the padded tail.",
+        )
+        row_idx = token_idx * num_heads + head_idx
+        num_rows = tl.num_programs(0) * num_heads
+        prefix_desc = tl.make_tensor_descriptor(
+            prefix_output,
+            shape=[num_rows, HEAD_SIZE],
+            strides=[prefix_head_stride, 1],
+            block_shape=[1, PADDED_HEAD_SIZE],
+        )
+        suffix_desc = tl.make_tensor_descriptor(
+            suffix_output,
+            shape=[num_rows, HEAD_SIZE],
+            strides=[prefix_head_stride, 1],
+            block_shape=[1, PADDED_HEAD_SIZE],
+        )
+        output_desc = tl.make_tensor_descriptor(
+            output,
+            shape=[num_rows, HEAD_SIZE],
+            strides=[output_head_stride, 1],
+            block_shape=[1, PADDED_HEAD_SIZE],
+        )
 
     # For tokens without context (token_idx >= prefill_tokens_with_context),
     # directly copy from suffix_output
@@ -119,27 +185,36 @@ def merge_attn_states_kernel(
                 s_lse,
             )
 
-        s_out = tl.load(
-            suffix_output
-            + token_idx * num_heads * prefix_head_stride
-            + head_idx * prefix_head_stride
-            + head_arange,
-            mask=head_mask,
-        )
+        if USE_TD:
+            s_out = suffix_desc.load([row_idx, 0]).reshape(PADDED_HEAD_SIZE)
+        else:
+            s_out = tl.load(
+                suffix_output
+                + token_idx * num_heads * prefix_head_stride
+                + head_idx * prefix_head_stride
+                + head_arange,
+                mask=head_mask,
+            )
 
         if USE_FP8:
             s_out = s_out * (1.0 / tl.load(output_scale))
             s_out = tl.clamp(s_out, FP8_MIN, FP8_MAX)
             s_out = s_out.to(output.dtype.element_ty)
 
-        tl.store(
-            output
-            + token_idx * num_heads * output_head_stride
-            + head_idx * output_head_stride
-            + head_arange,
-            s_out,
-            mask=head_mask,
-        )
+        if USE_TD:
+            output_desc.store(
+                [row_idx, 0],
+                s_out.to(output.dtype.element_ty).reshape(1, PADDED_HEAD_SIZE),
+            )
+        else:
+            tl.store(
+                output
+                + token_idx * num_heads * output_head_stride
+                + head_idx * output_head_stride
+                + head_arange,
+                s_out,
+                mask=head_mask,
+            )
         return
 
     # For tokens with context (token_idx < prefill_tokens_with_context),
@@ -183,20 +258,24 @@ def merge_attn_states_kernel(
             out_lse,
         )
 
-    p_out = tl.load(
-        prefix_output
-        + token_idx * num_heads * prefix_head_stride
-        + head_idx * prefix_head_stride
-        + head_arange,
-        mask=head_mask,
-    )
-    s_out = tl.load(
-        suffix_output
-        + token_idx * num_heads * prefix_head_stride
-        + head_idx * prefix_head_stride
-        + head_arange,
-        mask=head_mask,
-    )
+    if USE_TD:
+        p_out = prefix_desc.load([row_idx, 0]).reshape(PADDED_HEAD_SIZE)
+        s_out = suffix_desc.load([row_idx, 0]).reshape(PADDED_HEAD_SIZE)
+    else:
+        p_out = tl.load(
+            prefix_output
+            + token_idx * num_heads * prefix_head_stride
+            + head_idx * prefix_head_stride
+            + head_arange,
+            mask=head_mask,
+        )
+        s_out = tl.load(
+            suffix_output
+            + token_idx * num_heads * prefix_head_stride
+            + head_idx * prefix_head_stride
+            + head_arange,
+            mask=head_mask,
+        )
 
     # NOTE(woosuk): Be careful with the numerical stability.
     # We should compute the scale first, and then multiply it with the output.
@@ -213,11 +292,17 @@ def merge_attn_states_kernel(
         out = tl.clamp(out, FP8_MIN, FP8_MAX)
         out = out.to(output.dtype.element_ty)
 
-    tl.store(
-        output
-        + token_idx * num_heads * output_head_stride
-        + head_idx * output_head_stride
-        + head_arange,
-        out,
-        mask=head_mask,
-    )
+    if USE_TD:
+        output_desc.store(
+            [row_idx, 0],
+            out.to(output.dtype.element_ty).reshape(1, PADDED_HEAD_SIZE),
+        )
+    else:
+        tl.store(
+            output
+            + token_idx * num_heads * output_head_stride
+            + head_idx * output_head_stride
+            + head_arange,
+            out,
+            mask=head_mask,
+        )


### PR DESCRIPTION
## What

Adds an opt-in `USE_TD` tensor-descriptor load/store path to `merge_attn_states_kernel`
in `vllm/v1/attention/ops/triton_merge_attn_states.py`, gated by `VLLM_TRITON_USE_TD` through
`vllm.triton_utils.use_tensor_descriptor()`. `USE_TD=False` keeps the
original pointer+mask path.

## Why

Evidence gathering for VLLMZ-1805 (TD enablement across vLLM Triton kernels).
This kernel was previously closed as *rejected* or *dropped*; we are
re-measuring every one of them on Intel Battlemage (B70) rather than relying on
the earlier verdicts, so the Triton Compiler team gets per-kernel numbers.

## Base

Branched from `afierka/td-base` (pinned at `5fd7a8883`) because the XPU
benchmark container is built from that commit — the mounted source tree has to
match the image's compiled extensions for the measurements to be valid.

## Testing

XPU only, TP=1. Kernel unit tests are run with `VLLM_TRITON_USE_TD=0` and
`=1`; E2E is `vllm bench sweep serve` on ShareGPT, 3 runs, median, seed 42,
prefix caching off. Results are attached to the campaign report, not here.

CUDA/ROCm correctness was **not** validated — this PR is a measurement vehicle
on the fork and is not proposed for upstream in this form.

AI assistance was used to produce this change.
