### PR TITLE
[XPU][TD] _fwd_kernel_stage2: tensor-descriptor path

### DIFF
--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -35,11 +35,14 @@ import torch
 from packaging import version
 
 from vllm.platforms import current_platform
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import tl, triton, use_tensor_descriptor
+from vllm.triton_utils.allocation import set_triton_allocator
 
 is_hip_ = current_platform.is_rocm()
 
 logger = logging.getLogger(__name__)
+
+_TD_ALLOCATOR_DEVICES: set[torch.device] = set()
 
 # Only print the following warnings when triton version < 3.2.0.
 # The issue won't affect performance or accuracy.
@@ -588,6 +591,7 @@ def _fwd_kernel_stage2(
     BLOCK_DV: tl.constexpr,
     Lv: tl.constexpr,
     OUTPUT_FP16: tl.constexpr = 0,
+    USE_TD: tl.constexpr = False,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -604,15 +608,31 @@ def _fwd_kernel_stage2(
     offs_v = cur_batch * stride_mid_ob + cur_head * stride_mid_oh + offs_d
     offs_logic = cur_batch * stride_mid_ob + cur_head * stride_mid_oh + Lv
 
+    if USE_TD:
+        # One [1, BLOCK_DV] tile per split. The descriptor shape stops at Lv,
+        # so lanes past Lv read as 0, matching the masked pointer load. The
+        # trailing LSE column is outside the descriptor and stays scalar.
+        mid_desc = tl.make_tensor_descriptor(
+            base=Mid_O + cur_batch * stride_mid_ob + cur_head * stride_mid_oh,
+            shape=[NUM_KV_SPLITS, Lv],
+            strides=[stride_mid_os, 1],
+            block_shape=[1, BLOCK_DV],
+        )
+
     for split_kv_id in range(0, NUM_KV_SPLITS):
         kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
         split_kv_start = kv_len_per_split * split_kv_id
         split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
 
         if split_kv_end > split_kv_start:
-            tv = tl.load(
-                Mid_O + offs_v + split_kv_id * stride_mid_os, mask=mask_d, other=0.0
-            )
+            if USE_TD:
+                tv = mid_desc.load([split_kv_id, 0]).reshape(BLOCK_DV)
+            else:
+                tv = tl.load(
+                    Mid_O + offs_v + split_kv_id * stride_mid_os,
+                    mask=mask_d,
+                    other=0.0,
+                )
             tlogic = tl.load(Mid_O + offs_logic + split_kv_id * stride_mid_os)
             n_e_max = tl.maximum(tlogic, e_max)
 
@@ -660,6 +680,21 @@ def _decode_softmax_reducev_fwd(
         # https://github.com/triton-lang/triton/blob/main/third_party/amd/backend/compiler.py
         extra_kargs = {"waves_per_eu": 4, "matrix_instr_nonkdim": 16, "kpack": 2}
 
+    # The stage-2 descriptor covers the per-split partial-output tile only. It
+    # needs a unit innermost stride, a 16-byte-multiple tile, and 16-byte
+    # aligned batch/head strides (the descriptor base is offset by both).
+    elem = logits.element_size()
+    use_td = (
+        use_tensor_descriptor()
+        and logits.stride(-1) == 1
+        and (BLOCK_DV * elem) % 16 == 0
+        and (logits.stride(0) * elem) % 16 == 0
+        and (logits.stride(1) * elem) % 16 == 0
+    )
+    if use_td and logits.device not in _TD_ALLOCATOR_DEVICES:
+        set_triton_allocator(logits.device)
+        _TD_ALLOCATOR_DEVICES.add(logits.device)
+
     grid = (batch, head_num)
     _fwd_kernel_stage2[grid](
         logits,
@@ -675,6 +710,7 @@ def _decode_softmax_reducev_fwd(
         NUM_KV_SPLITS=NUM_KV_SPLITS,
         BLOCK_DV=BLOCK_DV,
         Lv=Lv,
+        USE_TD=use_td,
         num_warps=4,
         num_stages=2,
         **extra_kargs,


### PR DESCRIPTION
## What

Adds an opt-in `USE_TD` tensor-descriptor load/store path to `_fwd_kernel_stage2`
in `vllm/v1/attention/ops/triton_decode_attention.py`, gated by `VLLM_TRITON_USE_TD` through
`vllm.triton_utils.use_tensor_descriptor()`. `USE_TD=False` keeps the
original pointer+mask path.

## Why

Evidence gathering for VLLMZ-1805 (TD enablement across vLLM Triton kernels).
This kernel was previously closed as *rejected* or *dropped*; we are
re-measuring every one of them on Intel Battlemage (B70) rather than relying on
the earlier verdicts, so the Triton Compiler team gets per-kernel numbers.

## Base

Branched from `afierka/td-base` (pinned at `5fd7a8883`) because the XPU
benchmark container is built from that commit — the mounted source tree has to
match the image's compiled extensions for the measurements to be valid.

## Testing

XPU only, TP=1. Kernel unit tests are run with `VLLM_TRITON_USE_TD=0` and
`=1`; E2E is `vllm bench sweep serve` on ShareGPT, 3 runs, median, seed 42,
prefix caching off. Results are attached to the campaign report, not here.

CUDA/ROCm correctness was **not** validated — this PR is a measurement vehicle
on the fork and is not proposed for upstream in this form.

AI assistance was used to produce this change.
